### PR TITLE
fix: on delete action, don't check for existence of refs/remotes/pull/####/merge

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8693,8 +8693,13 @@ const heroku = __nccwpck_require__(7213);
 async function createController(params) {
   const { pipelineName, pipelineId, appName, refName } = params;
 
-  if (await heroku.appExists(appName)) {
+  // Additional validation specific to the "create" action
+  const exists = await heroku.appExists(appName);
+  if (exists) {
     throw new Error(`Unable to create new PR app: an app named "${appName}" app already exists on Heroku`);
+  }
+  if (!git.refExists(refName)) {
+    throw new Error(`Ref "${refName}" does not exist.`);
   }
 
   const configVars = await heroku.getPipelineVars(pipelineId);
@@ -8807,9 +8812,13 @@ const heroku = __nccwpck_require__(7213);
 async function updateController(params) {
   const { pipelineName, appName, refName } = params;
 
+  // Additional validation specific to the "update" action
   const exists = await heroku.appExists(appName);
   if (!exists) {
     throw new Error(`Unable to update PR app: there is no app named "${appName}" on Heroku`);
+  }
+  if (!git.refExists(refName)) {
+    throw new Error(`Ref "${refName}" does not exist.`);
   }
 
   let appUrl;
@@ -9136,9 +9145,6 @@ async function getParams() {
   }
 
   const refName = `refs/remotes/pull/${prNumber}/merge`;
-  if (!git.refExists(refName)) {
-    throw new Error(`Ref "${refName}" does not exist.`);
-  }
 
   return { pipelineName, pipelineId, baseName, appName, refName };
 }

--- a/src/controllers/create.js
+++ b/src/controllers/create.js
@@ -6,8 +6,13 @@ const heroku = require('../heroku');
 async function createController(params) {
   const { pipelineName, pipelineId, appName, refName } = params;
 
-  if (await heroku.appExists(appName)) {
+  // Additional validation specific to the "create" action
+  const exists = await heroku.appExists(appName);
+  if (exists) {
     throw new Error(`Unable to create new PR app: an app named "${appName}" app already exists on Heroku`);
+  }
+  if (!git.refExists(refName)) {
+    throw new Error(`Ref "${refName}" does not exist.`);
   }
 
   const configVars = await heroku.getPipelineVars(pipelineId);

--- a/src/controllers/update.js
+++ b/src/controllers/update.js
@@ -6,9 +6,13 @@ const heroku = require('../heroku');
 async function updateController(params) {
   const { pipelineName, appName, refName } = params;
 
+  // Additional validation specific to the "update" action
   const exists = await heroku.appExists(appName);
   if (!exists) {
     throw new Error(`Unable to update PR app: there is no app named "${appName}" on Heroku`);
+  }
+  if (!git.refExists(refName)) {
+    throw new Error(`Ref "${refName}" does not exist.`);
   }
 
   let appUrl;

--- a/src/main.js
+++ b/src/main.js
@@ -39,9 +39,6 @@ async function getParams() {
   }
 
   const refName = `refs/remotes/pull/${prNumber}/merge`;
-  if (!git.refExists(refName)) {
-    throw new Error(`Ref "${refName}" does not exist.`);
-  }
 
   return { pipelineName, pipelineId, baseName, appName, refName };
 }


### PR DESCRIPTION
The GitHub Action checks for a branch (ref) in the git repo called `refs/remotes/pull/####/merge` (where #### is the PR number). It ran this check on all runs (create + update + delete) and threw an error if that ref was missing.

Turns out that the ref doesn't exist when a PR is _merged and closed_. This isn't a problem for us — we don't need it to delete the review app after the PR is merged. But the validation was throwing an error because of it.

(Wasn't caught in testing because all my testing was done by closing PRs instead of merging them. I guess this is only an issue if the PR is merged into another branch.)

Examples of deletions that failed — I'll clean up these Heroku apps myself:
* Deploybert: https://github.com/readmeio/deploybert/runs/6393858412?check_suite_focus=true
* Markdown: https://github.com/readmeio/markdown/runs/6393901477?check_suite_focus=true
