### PR TITLE
feat: configure a log drain on new review apps

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8704,7 +8704,7 @@ async function createController(params) {
 
   const configVars = await heroku.getPipelineVars(pipelineId);
 
-  let stepCount = 4;
+  let stepCount = 5;
   if (Object.keys(configVars).length > 0) {
     stepCount += 1;
   }
@@ -8732,6 +8732,10 @@ async function createController(params) {
     core.info(`[Step ${currentStep}/${stepCount}] Setting default config vars...`);
     await heroku.setAppVars(app.id, configVars);
   }
+
+  currentStep += 1;
+  core.info(`[Step ${currentStep}/${stepCount}] Configuring app to send logs to Logstash...`);
+  await heroku.addDrain(app.id, `https://logging.rdme.io/heroku/development/${appName}`);
 
   currentStep += 1;
   core.info(
@@ -9084,6 +9088,18 @@ module.exports.setAppVars = async function (appId, vars) {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(vars),
+  });
+  return resp.json();
+};
+
+/*
+ * Adds a log drain to the given app
+ */
+module.exports.addDrain = async function (appId, url) {
+  const resp = await herokuFetch(`https://api.heroku.com/apps/${appId}/log-drains`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url }),
   });
   return resp.json();
 };

--- a/src/controllers/create.js
+++ b/src/controllers/create.js
@@ -17,7 +17,7 @@ async function createController(params) {
 
   const configVars = await heroku.getPipelineVars(pipelineId);
 
-  let stepCount = 4;
+  let stepCount = 5;
   if (Object.keys(configVars).length > 0) {
     stepCount += 1;
   }
@@ -45,6 +45,10 @@ async function createController(params) {
     core.info(`[Step ${currentStep}/${stepCount}] Setting default config vars...`);
     await heroku.setAppVars(app.id, configVars);
   }
+
+  currentStep += 1;
+  core.info(`[Step ${currentStep}/${stepCount}] Configuring app to send logs to Logstash...`);
+  await heroku.addDrain(app.id, `https://logging.rdme.io/heroku/development/${appName}`);
 
   currentStep += 1;
   core.info(

--- a/src/heroku.js
+++ b/src/heroku.js
@@ -186,6 +186,18 @@ module.exports.setAppVars = async function (appId, vars) {
   return resp.json();
 };
 
+/*
+ * Adds a log drain to the given app
+ */
+module.exports.addDrain = async function (appId, url) {
+  const resp = await herokuFetch(`https://api.heroku.com/apps/${appId}/log-drains`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url }),
+  });
+  return resp.json();
+};
+
 /* Creates a new one-off dyno to run the given command in the background. */
 module.exports.runAppCommand = async function (appId, command) {
   const resp = await herokuFetch(`https://api.heroku.com/apps/${appId}/dynos`, {

--- a/test/heroku.test.js
+++ b/test/heroku.test.js
@@ -5,6 +5,7 @@ const SAMPLE_APP_ID = '33333333-4444-5555-6666-777777777777';
 const SAMPLE_APP_NAME = 'dr-owlbert-pr-1234';
 const SAMPLE_COMMAND = 'npm run lint';
 const SAMPLE_CONFIG_VARS = { MAILCHIMP_API_KEY: '123', NODE_ENV: 'pr' };
+const SAMPLE_DRAIN_URL = 'https://logs.example.com/my-log-drain';
 const SAMPLE_PIPELINE_ID = '12121212-3434-5656-7878-909090909090';
 const SAMPLE_PIPELINE_NAME = 'aqueduct';
 const SAMPLE_RESPONSE = { response_field: 'response_value' };
@@ -129,6 +130,15 @@ describe('#src/heroku', () => {
           .patch(`/apps/${SAMPLE_APP_ID}/config-vars`, SAMPLE_CONFIG_VARS)
           .reply(200, SAMPLE_RESPONSE);
         await expect(heroku.setAppVars(SAMPLE_APP_ID, SAMPLE_CONFIG_VARS)).resolves.toStrictEqual(SAMPLE_RESPONSE);
+      });
+    });
+
+    describe('addDrain()', () => {
+      it('should POST to the correct endpoint to set up a log drain', async () => {
+        nock('https://api.heroku.com')
+          .post(`/apps/${SAMPLE_APP_ID}/log-drains`, { url: SAMPLE_DRAIN_URL })
+          .reply(200, SAMPLE_RESPONSE);
+        await expect(heroku.addDrain(SAMPLE_APP_ID, SAMPLE_DRAIN_URL)).resolves.toStrictEqual(SAMPLE_RESPONSE);
       });
     });
 


### PR DESCRIPTION
New feature I should have added earlier — this ensures that review apps' logs are sent to Logstash, like all our other apps.