### PR TITLE
feat: allow config vars to optionally populate from a template app

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   pipeline_name:
     description: "The name of the Heroku pipeline where the app should be deployed"
     required: true
+  config_template_app:
+    description: "If present, config vars wil be copied from this app instead of from pipeline CI defaults"
+    required: false
   github_token:
     description: 'GITHUB_TOKEN or a repo scoped PAT.'
     default: ${{ github.token }}

--- a/src/controllers/create.js
+++ b/src/controllers/create.js
@@ -4,7 +4,7 @@ const git = require('../git');
 const heroku = require('../heroku');
 
 async function createController(params) {
-  const { pipelineName, pipelineId, appName, refName } = params;
+  const { pipelineName, pipelineId, templateApp, appName, refName } = params;
 
   // Additional validation specific to the "create" action
   const exists = await heroku.appExists(appName);
@@ -15,7 +15,7 @@ async function createController(params) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
 
-  const configVars = await heroku.getPipelineVars(pipelineId);
+  const configVars = templateApp ? await heroku.getAppVars(templateApp) : await heroku.getPipelineVars(pipelineId);
 
   let stepCount = 4;
   if (Object.keys(configVars).length > 0) {

--- a/src/heroku.js
+++ b/src/heroku.js
@@ -73,6 +73,21 @@ module.exports.getApp = async function (appName) {
   return herokuGet(`https://api.heroku.com/apps/${appName}`);
 };
 
+/*
+ * Loads all of the config vars for the given app. Filters out vars that are
+ * set by the Heroku Labs feature "runtime-dyno-metadata".
+ */
+module.exports.getAppVars = async function (appName) {
+  const vars = await herokuGet(`https://api.heroku.com/apps/${appName}/config-vars`);
+  delete vars.HEROKU_APP_ID;
+  delete vars.HEROKU_APP_NAME;
+  delete vars.HEROKU_RELEASE_CREATED_AT;
+  delete vars.HEROKU_RELEASE_VERSION;
+  delete vars.HEROKU_SLUG_COMMIT;
+  delete vars.HEROKU_SLUG_DESCRIPTION;
+  return vars;
+};
+
 /* Loads the UUID of the named pipeline from Heroku. */
 module.exports.getPipelineId = async function (pipelineName) {
   try {

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,14 @@ async function getParams() {
     throw new Error(`The pipeline "${pipelineName}" does not exist on Heroku`);
   }
 
+  const templateApp = core.getInput('config_template_app', { required: false });
+  if (templateApp) {
+    const exists = await heroku.appExists(templateApp);
+    if (!exists) {
+      throw new Error(`The template app "${templateApp}" does not exist on Heroku`);
+    }
+  }
+
   let baseName;
   const reviewAppConfig = await heroku.getReviewAppConfig(pipelineId);
   if (reviewAppConfig) {
@@ -40,7 +48,7 @@ async function getParams() {
 
   const refName = `refs/remotes/pull/${prNumber}/merge`;
 
-  return { pipelineName, pipelineId, baseName, appName, refName };
+  return { pipelineName, pipelineId, templateApp, baseName, appName, refName };
 }
 
 /*
@@ -51,13 +59,14 @@ async function main() {
     heroku.initializeCredentials();
 
     const params = await getParams();
-    const { pipelineName, pipelineId, baseName, appName, refName } = params;
+    const { pipelineName, pipelineId, baseName, appName, refName, templateApp } = params;
 
     core.info('Heroku Review App Action invoked with these parameters:');
     core.info(`  - Action: ${github.context.payload.action}`);
     core.info(`  - Git ref: ${refName}`);
     core.info(`  - Heroku pipeline name: ${pipelineName}`);
     core.info(`  - Heroku pipeline ID: ${pipelineId}`);
+    core.info(`  - Config template app: ${templateApp || 'none'}`);
     core.info(`  - Review app base name: ${baseName}`);
     core.info(`  - Heroku app name: ${appName}`);
 

--- a/test/heroku.test.js
+++ b/test/heroku.test.js
@@ -31,6 +31,37 @@ describe('#src/heroku', () => {
       });
     });
 
+    describe('getAppVars()', () => {
+      it('should return the config vars for the given app', async () => {
+        nock('https://api.heroku.com').get(`/apps/${SAMPLE_APP_NAME}/config-vars`).reply(200, SAMPLE_CONFIG_VARS);
+        await expect(heroku.getAppVars(SAMPLE_APP_NAME)).resolves.toStrictEqual(SAMPLE_CONFIG_VARS);
+      });
+
+      it('should throw an error if the app does not exist', async () => {
+        nock('https://api.heroku.com').get(`/apps/${SAMPLE_APP_NAME}/config-vars`).reply(404);
+        await expect(heroku.getAppVars(SAMPLE_APP_NAME)).rejects.toThrow(/404/);
+      });
+
+      it('should filter config vars from the Heroku Labs feature "runtime-dyno-metadata"', async () => {
+        const allVars = {
+          HEROKU_APP_ID: SAMPLE_APP_ID,
+          HEROKU_APP_NAME: SAMPLE_APP_NAME,
+          HEROKU_IS_AWESOME: 'not exactly',
+          HEROKU_RELEASE_CREATED_AT: '2022-04-01T00:00:00Z',
+          HEROKU_RELEASE_VERSION: 'v255',
+          HEROKU_SLUG_COMMIT: '0123456789abcdef0123456789abcdef01234567',
+          HEROKU_SLUG_DESCRIPTION: 'Deploy 01234567',
+          README_IS_AWESOME: 'definitely',
+        };
+        const filteredVars = {
+          HEROKU_IS_AWESOME: 'not exactly',
+          README_IS_AWESOME: 'definitely',
+        };
+        nock('https://api.heroku.com').get(`/apps/${SAMPLE_APP_NAME}/config-vars`).reply(200, allVars);
+        await expect(heroku.getAppVars(SAMPLE_APP_NAME)).resolves.toStrictEqual(filteredVars);
+      });
+    });
+
     describe('getPipelineId()', () => {
       it('should return the UUID of the given pipeline', async () => {
         nock('https://api.heroku.com').get(`/pipelines/${SAMPLE_PIPELINE_NAME}`).reply(200, { id: SAMPLE_PIPELINE_ID });


### PR DESCRIPTION
**Problem:** Some pipelines, like deploybert, were never configured to use review apps when the Heroku-GitHub integration was working. Now we can't enable review apps for those pipelines because the integration is down. But without enabling review apps, we can't set any default config vars for those pipelines.

**Solution:** I've added a new parameter to our custom GitHub Action, called `config_template_app`. When present, config vars will be copied from the given app instead of from the pipeline defaults.

**Testing:** Tested on metrics-test-server by copying vars from `metrics-test-staging`. When I opened a new review app, it correctly copied vars (`API_KEY`, `HOST`, `JWT_SECRET`) and it didn't overwrite the dyno metadata vars.

<img width="1106" alt="Screen_Shot_2022-05-17_at_11_18_55_AM" src="https://user-images.githubusercontent.com/313895/168883771-46e5c2b0-c420-425a-8669-a707b7d1f7b7.png">

**Shout out:** Kanad, for successfully debugging my testing process 🙌🏼 