### PR TITLE
fix: move <img> tag to end of headline to fix Slack notifications

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8627,24 +8627,22 @@ async function postComment(body) {
 }
 
 function formatComment(options) {
-  let result = '';
+  let img = '';
   if (options.image) {
     if (options.imageLink) {
-      result += `<a href="${options.imageLink}">`;
+      img += `<a href="${options.imageLink}">`;
     }
-    result += `<img align="right" height="100" src="${options.image}" />`;
+    img += `<img align="right" height="100" src="${options.image}" />`;
     if (options.imageLink) {
-      result += `</a>`;
+      img += `</a>`;
     }
   }
 
-  if (options.headline) {
-    result += `\n\n## ${options.headline}`;
-  }
-
+  let result = options.headline ? `## ${options.headline} ${img}` : img;
   if (options.body) {
     result += `\n\n${options.body}`;
   }
+
   return result;
 }
 
@@ -8664,7 +8662,7 @@ module.exports.postUpdateComment = async function (appName, appUrl) {
   const comment = formatComment({
     image: owlberts.update,
     imageLink: appUrl,
-    headline: 'This PR‘s review app has been redeployed!',
+    headline: 'This PR’s review app has been redeployed!',
     body: `:mag: **Inspect the app:** ${dashboardUrl}\n\n:compass: **Take it for a spin:** ${appUrl}`,
   });
   return postComment(comment);

--- a/src/comments.js
+++ b/src/comments.js
@@ -34,7 +34,7 @@ function formatComment(options) {
     }
   }
 
-  let result = options.headline ? `## ${img} ${options.headline}` : img;
+  let result = options.headline ? `## ${options.headline} ${img}` : img;
   if (options.body) {
     result += `\n\n${options.body}`;
   }


### PR DESCRIPTION
**Problem:** GitHub comments are forwarded to Slack thanks to the GitHub integration. But because our comments start with an `<img>` tag, the comments look like this:

<img width="638" alt="Screen Shot 2022-05-17 at 11 42 57 AM" src="https://user-images.githubusercontent.com/313895/168887079-e80b8d31-d4d3-41d6-86e9-f0f2a0397261.png">

**Solution:** Move the `<img>` tag to the end of the headline. Confirmed this works without breaking the formatting:

<img width="918" alt="Screen Shot 2022-05-17 at 11 42 45 AM" src="https://user-images.githubusercontent.com/313895/168887166-be09d610-37b5-4f71-971e-ea033a7c584a.png">