### PR TITLE
feat: include the commit deployed in PR comments

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8656,12 +8656,6 @@ function getOctokit() {
  * the PR is closed and reopened, this the most recent.
  */
 async function findExistingComment() {
-  core.info('calling octokit.rest.issues.listComments with these params:');
-  core.info(`    owner: ${github.context.payload.repository.owner.login}`);
-  core.info(`    repo: ${github.context.payload.repository.name}`);
-  core.info(`    issue_number: ${parseInt(github.context.payload.number, 10)}`);
-  core.info('    per_page: 100');
-
   const octokit = getOctokit();
   const resp = await octokit.rest.issues.listComments({
     owner: github.context.payload.repository.owner.login,
@@ -8669,10 +8663,11 @@ async function findExistingComment() {
     issue_number: parseInt(github.context.payload.number, 10),
     per_page: 100,
   });
-  // TODO validate resp
-  core.info(`GitHub API returned status ${resp.status} and ${resp.data.length} comments`);
+  if (resp.status > 400) {
+    core.warning(`GitHub listComments API call returned HTTP status ${resp.status}`);
+    return undefined;
+  }
   const reviewAppComments = resp.data.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes(owlbert));
-  core.info(`With filter, there are ${reviewAppComments.length} matching comments`);
   if (reviewAppComments.length > 0) {
     // the last comment in the array is the most recent
     return reviewAppComments[reviewAppComments.length - 1];
@@ -8684,21 +8679,16 @@ async function findExistingComment() {
  * Sends a new comment to GitHub.
  */
 async function createComment(body) {
-  core.info('calling octokit.rest.issues.createComment with these params:');
-  core.info(`    owner: ${github.context.payload.repository.owner.login}`);
-  core.info(`    repo: ${github.context.payload.repository.name}`);
-  core.info(`    issue_number: ${parseInt(github.context.payload.number, 10)}`);
-  core.info(`    body: ${body.length} characters`);
-
   const octokit = getOctokit();
-  const resp = octokit.rest.issues.createComment({
+  const resp = await octokit.rest.issues.createComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     issue_number: parseInt(github.context.payload.number, 10),
     body,
   });
-  // TODO validate resp
-  core.info(`GitHub API returned status ${resp.status}`);
+  if (resp.status > 400) {
+    core.warning(`GitHub createComment API call returned HTTP status ${resp.status}`);
+  }
   return resp;
 }
 
@@ -8706,21 +8696,16 @@ async function createComment(body) {
  * Modifies an existing comment on GitHub.
  */
 async function updateComment(commentId, body) {
-  core.info('calling octokit.rest.issues.updateComment with these params:');
-  core.info(`    owner: ${github.context.payload.repository.owner.login}`);
-  core.info(`    repo: ${github.context.payload.repository.name}`);
-  core.info(`    comment_id: ${commentId}`);
-  core.info(`    body: ${body.length} characters`);
-
   const octokit = getOctokit();
-  const resp = octokit.rest.issues.updateComment({
+  const resp = await octokit.rest.issues.updateComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     comment_id: commentId,
     body,
   });
-  // TODO validate resp
-  core.info(`GitHub API returned status ${resp.status}`);
+  if (resp.status > 400) {
+    core.warning(`GitHub updateComment API call returned HTTP status ${resp.status}`);
+  }
   return resp;
 }
 
@@ -8728,32 +8713,20 @@ async function updateComment(commentId, body) {
  * Entrypoint to post a new PR comment when we open a new review app.
  */
 module.exports.postCreateComment = async function (appName, appUrl) {
-  core.info('running postCreateComment with these params:');
-  core.info(`    appName: ${appName}`);
-  core.info(`    appUrl: ${appUrl}`);
-
   const dashboardUrl = `https://dashboard.heroku.com/apps/${appName}`;
   const img = `<a href="${appUrl}"><img align="right" height="100" src="${owlbert}" /></a>`;
   const links = `:mag: **Inspect the app:** ${dashboardUrl}\n\n:compass: **Take it for a spin:** ${appUrl}`;
 
   const comment = `## A review app has been launched for this PR! ${img}\n\n${links}\n`;
-  const resp = await createComment(comment);
-
-  core.info('Finished running postCreateComment\n');
-  return resp;
+  return createComment(comment);
 };
 
 /*
- * Entrypoint to update the existing PR comment when we open a new review app.
- * If this can't find an existing PR comment, it can just create a new one.
+ * Entrypoint to update the existing PR comment, appending a bullet that we've
+ * redeployed the review app. If this can't find an existing PR comment, it will
+ * create a new comment instead.
  */
 module.exports.postUpdateComment = async function (appName, appUrl, sha, message) {
-  core.info('running postUpdateComment with these params:');
-  core.info(`    appName: ${appName}`);
-  core.info(`    appUrl: ${appUrl}`);
-  core.info(`    sha: ${sha}`);
-  core.info(`    message: ${message}`);
-
   const comment = await findExistingComment();
   if (!comment) {
     return module.exports.postCreateComment(appName, appUrl);
@@ -8768,18 +8741,15 @@ module.exports.postUpdateComment = async function (appName, appUrl, sha, message
   const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
   const body = `${comment.body}\n- **Redeployed on ${date}:** [\`${shortSha}\` ${message}](${commitLink})`;
 
-  const resp = await updateComment(comment.id, body);
-
-  core.info('Finished running postUpdateComment\n');
-  return resp;
+  return updateComment(comment.id, body);
 };
 
 /*
- * Entrypoint to update the existing PR comment when we close a review app.
- * If this can't find an existing PR comment, it doesn't do anything.
+ * Entrypoint to update the existing PR comment, appending a bullet that we've
+ * shut down the review app. If this can't find an existing PR comment, it
+ * doesn't do anything.
  */
 module.exports.postDeleteComment = async function () {
-  core.info('running postDeleteComment with no params:');
   const comment = await findExistingComment();
   if (!comment) {
     return undefined;
@@ -8787,10 +8757,7 @@ module.exports.postDeleteComment = async function () {
 
   const date = getFormattedDate();
   const body = `${comment.body}\n- **Shut down on ${date}:** Since this PR is closed, its review app has been cleaned up. :sponge:`;
-  const resp = await updateComment(comment.id, body);
-
-  core.info('Finished running postDeleteComment\n');
-  return resp;
+  return updateComment(comment.id, body);
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8759,14 +8759,9 @@ module.exports.postUpdateComment = async function (appName, appUrl, sha, message
     return module.exports.postCreateComment(appName, appUrl);
   }
 
-  const owner = github.context.payload.repository.owner.login;
-  const repo = github.context.payload.repository.name;
-  const prNumber = parseInt(github.context.payload.number, 10);
-
   const date = getFormattedDate();
   const shortSha = sha.substring(0, 7);
-  const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
-  const body = `${comment.body}\n- **Redeployed on ${date}:** [\`${shortSha}\` ${message}](${commitLink})`;
+  const body = `${comment.body}\n- **Redeployed on ${date}:** ${shortSha} ${message}`;
 
   const resp = await updateComment(comment.id, body);
 
@@ -8936,7 +8931,7 @@ async function updateController(params) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
   const sha = git.shaForRef(refName); // can't use github.context.sha because we want to exclude merge commits
-  const message = git.messageForRef(refName).split('\n')[0]; // only include the first line in the comment
+  const message = git.messageForRef(refName);
 
   let appUrl;
   if (pipelineName === 'readme') {
@@ -8994,7 +8989,8 @@ function gitLog(ref, format) {
   if (result.status !== 0) {
     return undefined;
   }
-  return result.stdout.toString().trim();
+  // convert the buffer to a string, then return just the first line
+  return result.stdout.toString().trim().split('\n')[0];
 }
 
 /* Checks whether the current directory contains a Git repo. Returns bool. */

--- a/dist/index.js
+++ b/dist/index.js
@@ -8605,20 +8605,75 @@ function wrappy (fn, cb) {
 const core = __nccwpck_require__(2186);
 const github = __nccwpck_require__(5438);
 
-const owlberts = {
-  create: 'https://user-images.githubusercontent.com/313895/167224035-b34efcd6-854e-4cb4-92bd-10d717d2a6b1.png',
-  update: 'https://user-images.githubusercontent.com/313895/167228091-63ba7dff-c41f-4359-bd59-10e7ed3972aa.png',
-  delete: 'https://user-images.githubusercontent.com/313895/167224468-051b838c-19fd-4133-97a5-7e73ce9dc366.png',
-};
+const owlbert = 'https://user-images.githubusercontent.com/313895/167224035-b34efcd6-854e-4cb4-92bd-10d717d2a6b1.png';
 
-async function postComment(body) {
-  const token = core.getInput('github_token', { required: false });
-  if (!token) {
-    core.info('GitHub API token not present, not commenting on this pull request');
-    return undefined;
+function getFormattedDate() {
+  const options = { weekday: 'short', year: undefined, month: 'short', day: 'numeric', timeZone: 'America/New_York' };
+  const dateString = new Date().toLocaleString('en-US', options);
+  // toLocaleString() with those options returns "Wed, May 25" but I'm pedantic
+  return dateString.replace(',', '');
+}
+
+/*
+ * Generates a stub with empty implementations of the Octokit functions we use
+ * here. This is helpful so that we don't have to have a lot of if-else logic
+ * throughout this module.
+ */
+function getFakeOctokit() {
+  return {
+    rest: {
+      issues: {
+        createComment: () => {},
+        updateComment: () => {},
+        listComments: () => [],
+      },
+    },
+  };
+}
+
+let octokit;
+
+/*
+ * Returns an instance of Octokit, or a stub if there's no auth token present.
+ */
+function getOctokit() {
+  if (!octokit) {
+    const token = core.getInput('github_token', { required: false });
+    if (!token) {
+      core.warning('GitHub API token not present, not commenting on this pull request');
+      octokit = getFakeOctokit();
+    }
+    octokit = github.getOctokit(token);
   }
+  return octokit;
+}
 
-  return github.getOctokit(token).rest.issues.createComment({
+/*
+ * Finds an existing comment from this GitHub Action on the current pull
+ * request. We can find the right comment by looking for one posted by a
+ * GitHub Action and with the Owlbert image in the body. If there is no
+ * matching comment, returns undefined. If there is more than one, like if
+ * the PR is closed and reopened, this the most recent.
+ */
+async function findExistingComment() {
+  const resp = await octokit.rest.issues.listComments({
+    owner: github.context.payload.repository.owner.login,
+    repo: github.context.payload.repository.name,
+    issue_number: parseInt(github.context.payload.number, 10),
+  });
+  const reviewAppComments = resp.data.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes(owlbert));
+  if (reviewAppComments.length > 0) {
+    // the last comment in the array is the most recent
+    return reviewAppComments[reviewAppComments.length - 1];
+  }
+  return undefined;
+}
+
+/*
+ * Sends a new comment to GitHub.
+ */
+async function createComment(body) {
+  return getOctokit().rest.issues.createComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     issue_number: parseInt(github.context.payload.number, 10),
@@ -8626,75 +8681,65 @@ async function postComment(body) {
   });
 }
 
-function formatComment(options) {
-  let img = '';
-  if (options.image) {
-    if (options.imageLink) {
-      img += `<a href="${options.imageLink}">`;
-    }
-    img += `<img align="right" height="100" src="${options.image}" />`;
-    if (options.imageLink) {
-      img += `</a>`;
-    }
-  }
-
-  let result = options.headline ? `## ${options.headline} ${img}` : img;
-  if (options.body) {
-    result += `\n\n${options.body}`;
-  }
-
-  return result;
+/*
+ * Modifies an existing comment on GitHub.
+ */
+async function updateComment(commentId, body) {
+  return getOctokit().rest.issues.updateComment({
+    owner: github.context.payload.repository.owner.login,
+    repo: github.context.payload.repository.name,
+    comment_id: commentId,
+    body,
+  });
 }
 
-function buildLinks(appName, appUrl, message) {
-  const links = [];
+/*
+ * Entrypoint to post a new PR comment when we open a new review app.
+ */
+module.exports.postCreateComment = async function (appName, appUrl) {
+  const dashboardUrl = `https://dashboard.heroku.com/apps/${appName}`;
+  const img = `<a href="${appUrl}"><img align="right" height="100" src="${owlbert}" /></a>`;
+  const links = `:mag: **Inspect the app:** ${dashboardUrl}\n\n:compass: **Take it for a spin:** ${appUrl}`;
+
+  const comment = `## A review app has been launched for this PR! ${img}\n\n${links}\n`;
+  return createComment(comment);
+};
+
+/*
+ * Entrypoint to update the existing PR comment when we open a new review app.
+ * If this can't find an existing PR comment, it can just create a new one.
+ */
+module.exports.postUpdateComment = async function (appName, appUrl, sha, message) {
+  const comment = await findExistingComment();
+  if (!comment) {
+    return module.exports.postCreateComment(appName, appUrl);
+  }
 
   const owner = github.context.payload.repository.owner.login;
   const repo = github.context.payload.repository.name;
   const prNumber = parseInt(github.context.payload.number, 10);
-  const sha = github.context.sha;
 
-  if (owner && repo && prNumber && sha && message) {
-    const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
-    const commitText = `\`${sha.substring(0, 8)}\` ${message.split('\n')[0]}`;
-    links.push(`:rocket: **Deployed commit:** [${commitText}](${commitLink})`);
+  const date = getFormattedDate();
+  const shortSha = sha.substring(0, 7);
+  const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
+  const body = `${comment.body}\n- **Redeployed on ${date}:** [\`${shortSha}\` ${message}](${commitLink})`;
+
+  return updateComment(comment.id, body);
+};
+
+/*
+ * Entrypoint to update the existing PR comment when we close a review app.
+ * If this can't find an existing PR comment, it doesn't do anything.
+ */
+module.exports.postDeleteComment = async function () {
+  const comment = await findExistingComment();
+  if (!comment) {
+    return undefined;
   }
 
-  const dashboardUrl = `https://dashboard.heroku.com/apps/${appName}`;
-  links.push(`:mag: **Inspect the app:** ${dashboardUrl}`);
-
-  links.push(`:compass: **Take it for a spin:** ${appUrl}`);
-
-  return links;
-}
-
-module.exports.postCreateComment = async function (appName, appUrl, message) {
-  const comment = formatComment({
-    image: owlberts.create,
-    imageLink: appUrl,
-    headline: 'A review app has been launched for this PR!',
-    body: buildLinks(appName, appUrl, message).join('\n\n'),
-  });
-  return postComment(comment);
-};
-
-module.exports.postUpdateComment = async function (appName, appUrl, message) {
-  const comment = formatComment({
-    image: owlberts.update,
-    imageLink: appUrl,
-    headline: 'This PR’s review app has been redeployed!',
-    body: buildLinks(appName, appUrl, message).join('\n\n'),
-  });
-  return postComment(comment);
-};
-
-module.exports.postDeleteComment = async function () {
-  const comment = formatComment({
-    image: owlberts.delete,
-    headline: 'This PR’s review app has been shut down.',
-    body: `:sponge: Since this PR is closed, its review app has been cleaned up.`,
-  });
-  return postComment(comment);
+  const date = getFormattedDate();
+  const body = `${comment.body}\n- **Shut down on ${date}:** Since this PR is closed, its review app has been cleaned up. :sponge:`;
+  return updateComment(comment.id, body);
 };
 
 
@@ -8826,6 +8871,7 @@ module.exports = deleteController;
 const comments = __nccwpck_require__(4975);
 const core = __nccwpck_require__(2186);
 const git = __nccwpck_require__(109);
+const github = __nccwpck_require__(5438);
 const heroku = __nccwpck_require__(7213);
 
 async function updateController(params) {
@@ -8839,6 +8885,7 @@ async function updateController(params) {
   if (!git.refExists(refName)) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
+  const sha = github.context.sha;
   const message = git.messageForRef(refName);
 
   let appUrl;
@@ -8858,7 +8905,7 @@ async function updateController(params) {
   }
 
   core.info(`\nSuccessfully deployed changes to Heroku app "${appName}"! Your app is available at:\n    ${appUrl}\n`);
-  await comments.postUpdateComment(appName, appUrl, message);
+  await comments.postUpdateComment(appName, appUrl, sha, message);
   return true;
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8625,7 +8625,7 @@ function getFakeOctokit() {
       issues: {
         createComment: () => {},
         updateComment: () => {},
-        listComments: () => [],
+        listComments: () => {},
       },
     },
   };
@@ -8661,12 +8661,15 @@ async function findExistingComment() {
   core.info(`    repo: ${github.context.payload.repository.name}`);
   core.info(`    issue_number: ${parseInt(github.context.payload.number, 10)}`);
   core.info('    per_page: 100');
+
+  const octokit = getOctokit();
   const resp = await octokit.rest.issues.listComments({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     issue_number: parseInt(github.context.payload.number, 10),
     per_page: 100,
   });
+  // TODO validate resp
   core.info(`GitHub API returned status ${resp.status} and ${resp.data.length} comments`);
   const reviewAppComments = resp.data.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes(owlbert));
   core.info(`With filter, there are ${reviewAppComments.length} matching comments`);
@@ -8687,12 +8690,14 @@ async function createComment(body) {
   core.info(`    issue_number: ${parseInt(github.context.payload.number, 10)}`);
   core.info(`    body: ${body.length} characters`);
 
-  const resp = await getOctokit().rest.issues.createComment({
+  const octokit = getOctokit();
+  const resp = octokit.rest.issues.createComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     issue_number: parseInt(github.context.payload.number, 10),
     body,
   });
+  // TODO validate resp
   core.info(`GitHub API returned status ${resp.status}`);
   return resp;
 }
@@ -8707,12 +8712,14 @@ async function updateComment(commentId, body) {
   core.info(`    comment_id: ${commentId}`);
   core.info(`    body: ${body.length} characters`);
 
-  const resp = getOctokit().rest.issues.updateComment({
+  const octokit = getOctokit();
+  const resp = octokit.rest.issues.updateComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     comment_id: commentId,
     body,
   });
+  // TODO validate resp
   core.info(`GitHub API returned status ${resp.status}`);
   return resp;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -8759,9 +8759,14 @@ module.exports.postUpdateComment = async function (appName, appUrl, sha, message
     return module.exports.postCreateComment(appName, appUrl);
   }
 
+  const owner = github.context.payload.repository.owner.login;
+  const repo = github.context.payload.repository.name;
+  const prNumber = parseInt(github.context.payload.number, 10);
+
   const date = getFormattedDate();
   const shortSha = sha.substring(0, 7);
-  const body = `${comment.body}\n- **Redeployed on ${date}:** ${shortSha} ${message}`;
+  const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
+  const body = `${comment.body}\n- **Redeployed on ${date}:** [\`${shortSha}\` ${message}](${commitLink})`;
 
   const resp = await updateComment(comment.id, body);
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8936,7 +8936,7 @@ async function updateController(params) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
   const sha = git.shaForRef(refName); // can't use github.context.sha because we want to exclude merge commits
-  const message = git.messageForRef(refName);
+  const message = git.messageForRef(refName).split('\n')[0]; // only include the first line in the comment
 
   let appUrl;
   if (pipelineName === 'readme') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -8656,12 +8656,20 @@ function getOctokit() {
  * the PR is closed and reopened, this the most recent.
  */
 async function findExistingComment() {
+  core.info('calling octokit.rest.issues.listComments with these params:');
+  core.info(`    owner: ${github.context.payload.repository.owner.login}`);
+  core.info(`    repo: ${github.context.payload.repository.name}`);
+  core.info(`    issue_number: ${parseInt(github.context.payload.number, 10)}`);
+  core.info('    per_page: 100');
   const resp = await octokit.rest.issues.listComments({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     issue_number: parseInt(github.context.payload.number, 10),
+    per_page: 100,
   });
+  core.info(`GitHub API returned status ${resp.status} and ${resp.data.length} comments`);
   const reviewAppComments = resp.data.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes(owlbert));
+  core.info(`With filter, there are ${reviewAppComments.length} matching comments`);
   if (reviewAppComments.length > 0) {
     // the last comment in the array is the most recent
     return reviewAppComments[reviewAppComments.length - 1];
@@ -8673,36 +8681,59 @@ async function findExistingComment() {
  * Sends a new comment to GitHub.
  */
 async function createComment(body) {
-  return getOctokit().rest.issues.createComment({
+  core.info('calling octokit.rest.issues.createComment with these params:');
+  core.info(`    owner: ${github.context.payload.repository.owner.login}`);
+  core.info(`    repo: ${github.context.payload.repository.name}`);
+  core.info(`    issue_number: ${parseInt(github.context.payload.number, 10)}`);
+  core.info(`    body: ${body.length} characters`);
+
+  const resp = await getOctokit().rest.issues.createComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     issue_number: parseInt(github.context.payload.number, 10),
     body,
   });
+  core.info(`GitHub API returned status ${resp.status}`);
+  return resp;
 }
 
 /*
  * Modifies an existing comment on GitHub.
  */
 async function updateComment(commentId, body) {
-  return getOctokit().rest.issues.updateComment({
+  core.info('calling octokit.rest.issues.updateComment with these params:');
+  core.info(`    owner: ${github.context.payload.repository.owner.login}`);
+  core.info(`    repo: ${github.context.payload.repository.name}`);
+  core.info(`    comment_id: ${commentId}`);
+  core.info(`    body: ${body.length} characters`);
+
+  const resp = getOctokit().rest.issues.updateComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     comment_id: commentId,
     body,
   });
+  core.info(`GitHub API returned status ${resp.status}`);
+  return resp;
 }
 
 /*
  * Entrypoint to post a new PR comment when we open a new review app.
  */
 module.exports.postCreateComment = async function (appName, appUrl) {
+  core.info('running postCreateComment with these params:');
+  core.info(`    appName: ${appName}`);
+  core.info(`    appUrl: ${appUrl}`);
+
   const dashboardUrl = `https://dashboard.heroku.com/apps/${appName}`;
   const img = `<a href="${appUrl}"><img align="right" height="100" src="${owlbert}" /></a>`;
   const links = `:mag: **Inspect the app:** ${dashboardUrl}\n\n:compass: **Take it for a spin:** ${appUrl}`;
 
   const comment = `## A review app has been launched for this PR! ${img}\n\n${links}\n`;
-  return createComment(comment);
+  const resp = await createComment(comment);
+
+  core.info('Finished running postCreateComment\n');
+  return resp;
 };
 
 /*
@@ -8710,6 +8741,12 @@ module.exports.postCreateComment = async function (appName, appUrl) {
  * If this can't find an existing PR comment, it can just create a new one.
  */
 module.exports.postUpdateComment = async function (appName, appUrl, sha, message) {
+  core.info('running postUpdateComment with these params:');
+  core.info(`    appName: ${appName}`);
+  core.info(`    appUrl: ${appUrl}`);
+  core.info(`    sha: ${sha}`);
+  core.info(`    message: ${message}`);
+
   const comment = await findExistingComment();
   if (!comment) {
     return module.exports.postCreateComment(appName, appUrl);
@@ -8724,7 +8761,10 @@ module.exports.postUpdateComment = async function (appName, appUrl, sha, message
   const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
   const body = `${comment.body}\n- **Redeployed on ${date}:** [\`${shortSha}\` ${message}](${commitLink})`;
 
-  return updateComment(comment.id, body);
+  const resp = await updateComment(comment.id, body);
+
+  core.info('Finished running postUpdateComment\n');
+  return resp;
 };
 
 /*
@@ -8732,6 +8772,7 @@ module.exports.postUpdateComment = async function (appName, appUrl, sha, message
  * If this can't find an existing PR comment, it doesn't do anything.
  */
 module.exports.postDeleteComment = async function () {
+  core.info('running postDeleteComment with no params:');
   const comment = await findExistingComment();
   if (!comment) {
     return undefined;
@@ -8739,7 +8780,10 @@ module.exports.postDeleteComment = async function () {
 
   const date = getFormattedDate();
   const body = `${comment.body}\n- **Shut down on ${date}:** Since this PR is closed, its review app has been cleaned up. :sponge:`;
-  return updateComment(comment.id, body);
+  const resp = await updateComment(comment.id, body);
+
+  core.info('Finished running postDeleteComment\n');
+  return resp;
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8631,21 +8631,21 @@ function getFakeOctokit() {
   };
 }
 
-let octokit;
+let memoizedOctokit;
 
 /*
  * Returns an instance of Octokit, or a stub if there's no auth token present.
  */
 function getOctokit() {
-  if (!octokit) {
+  if (!memoizedOctokit) {
     const token = core.getInput('github_token', { required: false });
     if (!token) {
       core.warning('GitHub API token not present, not commenting on this pull request');
-      octokit = getFakeOctokit();
+      memoizedOctokit = getFakeOctokit();
     }
-    octokit = github.getOctokit(token);
+    memoizedOctokit = github.getOctokit(token);
   }
-  return octokit;
+  return memoizedOctokit;
 }
 
 /*

--- a/src/comments.js
+++ b/src/comments.js
@@ -27,21 +27,21 @@ function getFakeOctokit() {
   };
 }
 
-let octokit;
+let memoizedOctokit;
 
 /*
  * Returns an instance of Octokit, or a stub if there's no auth token present.
  */
 function getOctokit() {
-  if (!octokit) {
+  if (!memoizedOctokit) {
     const token = core.getInput('github_token', { required: false });
     if (!token) {
       core.warning('GitHub API token not present, not commenting on this pull request');
-      octokit = getFakeOctokit();
+      memoizedOctokit = getFakeOctokit();
     }
-    octokit = github.getOctokit(token);
+    memoizedOctokit = github.getOctokit(token);
   }
-  return octokit;
+  return memoizedOctokit;
 }
 
 /*

--- a/src/comments.js
+++ b/src/comments.js
@@ -155,9 +155,14 @@ module.exports.postUpdateComment = async function (appName, appUrl, sha, message
     return module.exports.postCreateComment(appName, appUrl);
   }
 
+  const owner = github.context.payload.repository.owner.login;
+  const repo = github.context.payload.repository.name;
+  const prNumber = parseInt(github.context.payload.number, 10);
+
   const date = getFormattedDate();
   const shortSha = sha.substring(0, 7);
-  const body = `${comment.body}\n- **Redeployed on ${date}:** ${shortSha} ${message}`;
+  const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
+  const body = `${comment.body}\n- **Redeployed on ${date}:** [\`${shortSha}\` ${message}](${commitLink})`;
 
   const resp = await updateComment(comment.id, body);
 

--- a/src/comments.js
+++ b/src/comments.js
@@ -21,7 +21,7 @@ function getFakeOctokit() {
       issues: {
         createComment: () => {},
         updateComment: () => {},
-        listComments: () => [],
+        listComments: () => {},
       },
     },
   };
@@ -57,12 +57,15 @@ async function findExistingComment() {
   core.info(`    repo: ${github.context.payload.repository.name}`);
   core.info(`    issue_number: ${parseInt(github.context.payload.number, 10)}`);
   core.info('    per_page: 100');
+
+  const octokit = getOctokit();
   const resp = await octokit.rest.issues.listComments({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     issue_number: parseInt(github.context.payload.number, 10),
     per_page: 100,
   });
+  // TODO validate resp
   core.info(`GitHub API returned status ${resp.status} and ${resp.data.length} comments`);
   const reviewAppComments = resp.data.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes(owlbert));
   core.info(`With filter, there are ${reviewAppComments.length} matching comments`);
@@ -83,12 +86,14 @@ async function createComment(body) {
   core.info(`    issue_number: ${parseInt(github.context.payload.number, 10)}`);
   core.info(`    body: ${body.length} characters`);
 
-  const resp = await getOctokit().rest.issues.createComment({
+  const octokit = getOctokit();
+  const resp = octokit.rest.issues.createComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     issue_number: parseInt(github.context.payload.number, 10),
     body,
   });
+  // TODO validate resp
   core.info(`GitHub API returned status ${resp.status}`);
   return resp;
 }
@@ -103,12 +108,14 @@ async function updateComment(commentId, body) {
   core.info(`    comment_id: ${commentId}`);
   core.info(`    body: ${body.length} characters`);
 
-  const resp = getOctokit().rest.issues.updateComment({
+  const octokit = getOctokit();
+  const resp = octokit.rest.issues.updateComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     comment_id: commentId,
     body,
   });
+  // TODO validate resp
   core.info(`GitHub API returned status ${resp.status}`);
   return resp;
 }

--- a/src/comments.js
+++ b/src/comments.js
@@ -1,20 +1,75 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
 
-const owlberts = {
-  create: 'https://user-images.githubusercontent.com/313895/167224035-b34efcd6-854e-4cb4-92bd-10d717d2a6b1.png',
-  update: 'https://user-images.githubusercontent.com/313895/167228091-63ba7dff-c41f-4359-bd59-10e7ed3972aa.png',
-  delete: 'https://user-images.githubusercontent.com/313895/167224468-051b838c-19fd-4133-97a5-7e73ce9dc366.png',
-};
+const owlbert = 'https://user-images.githubusercontent.com/313895/167224035-b34efcd6-854e-4cb4-92bd-10d717d2a6b1.png';
 
-async function postComment(body) {
-  const token = core.getInput('github_token', { required: false });
-  if (!token) {
-    core.info('GitHub API token not present, not commenting on this pull request');
-    return undefined;
+function getFormattedDate() {
+  const options = { weekday: 'short', year: undefined, month: 'short', day: 'numeric', timeZone: 'America/New_York' };
+  const dateString = new Date().toLocaleString('en-US', options);
+  // toLocaleString() with those options returns "Wed, May 25" but I'm pedantic
+  return dateString.replace(',', '');
+}
+
+/*
+ * Generates a stub with empty implementations of the Octokit functions we use
+ * here. This is helpful so that we don't have to have a lot of if-else logic
+ * throughout this module.
+ */
+function getFakeOctokit() {
+  return {
+    rest: {
+      issues: {
+        createComment: () => {},
+        updateComment: () => {},
+        listComments: () => [],
+      },
+    },
+  };
+}
+
+let octokit;
+
+/*
+ * Returns an instance of Octokit, or a stub if there's no auth token present.
+ */
+function getOctokit() {
+  if (!octokit) {
+    const token = core.getInput('github_token', { required: false });
+    if (!token) {
+      core.warning('GitHub API token not present, not commenting on this pull request');
+      octokit = getFakeOctokit();
+    }
+    octokit = github.getOctokit(token);
   }
+  return octokit;
+}
 
-  return github.getOctokit(token).rest.issues.createComment({
+/*
+ * Finds an existing comment from this GitHub Action on the current pull
+ * request. We can find the right comment by looking for one posted by a
+ * GitHub Action and with the Owlbert image in the body. If there is no
+ * matching comment, returns undefined. If there is more than one, like if
+ * the PR is closed and reopened, this the most recent.
+ */
+async function findExistingComment() {
+  const resp = await octokit.rest.issues.listComments({
+    owner: github.context.payload.repository.owner.login,
+    repo: github.context.payload.repository.name,
+    issue_number: parseInt(github.context.payload.number, 10),
+  });
+  const reviewAppComments = resp.data.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes(owlbert));
+  if (reviewAppComments.length > 0) {
+    // the last comment in the array is the most recent
+    return reviewAppComments[reviewAppComments.length - 1];
+  }
+  return undefined;
+}
+
+/*
+ * Sends a new comment to GitHub.
+ */
+async function createComment(body) {
+  return getOctokit().rest.issues.createComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     issue_number: parseInt(github.context.payload.number, 10),
@@ -22,73 +77,63 @@ async function postComment(body) {
   });
 }
 
-function formatComment(options) {
-  let img = '';
-  if (options.image) {
-    if (options.imageLink) {
-      img += `<a href="${options.imageLink}">`;
-    }
-    img += `<img align="right" height="100" src="${options.image}" />`;
-    if (options.imageLink) {
-      img += `</a>`;
-    }
-  }
-
-  let result = options.headline ? `## ${options.headline} ${img}` : img;
-  if (options.body) {
-    result += `\n\n${options.body}`;
-  }
-
-  return result;
+/*
+ * Modifies an existing comment on GitHub.
+ */
+async function updateComment(commentId, body) {
+  return getOctokit().rest.issues.updateComment({
+    owner: github.context.payload.repository.owner.login,
+    repo: github.context.payload.repository.name,
+    comment_id: commentId,
+    body,
+  });
 }
 
-function buildLinks(appName, appUrl, message) {
-  const links = [];
+/*
+ * Entrypoint to post a new PR comment when we open a new review app.
+ */
+module.exports.postCreateComment = async function (appName, appUrl) {
+  const dashboardUrl = `https://dashboard.heroku.com/apps/${appName}`;
+  const img = `<a href="${appUrl}"><img align="right" height="100" src="${owlbert}" /></a>`;
+  const links = `:mag: **Inspect the app:** ${dashboardUrl}\n\n:compass: **Take it for a spin:** ${appUrl}`;
+
+  const comment = `## A review app has been launched for this PR! ${img}\n\n${links}\n`;
+  return createComment(comment);
+};
+
+/*
+ * Entrypoint to update the existing PR comment when we open a new review app.
+ * If this can't find an existing PR comment, it can just create a new one.
+ */
+module.exports.postUpdateComment = async function (appName, appUrl, sha, message) {
+  const comment = await findExistingComment();
+  if (!comment) {
+    return module.exports.postCreateComment(appName, appUrl);
+  }
 
   const owner = github.context.payload.repository.owner.login;
   const repo = github.context.payload.repository.name;
   const prNumber = parseInt(github.context.payload.number, 10);
-  const sha = github.context.sha;
 
-  if (owner && repo && prNumber && sha && message) {
-    const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
-    const commitText = `\`${sha.substring(0, 8)}\` ${message.split('\n')[0]}`;
-    links.push(`:rocket: **Deployed commit:** [${commitText}](${commitLink})`);
+  const date = getFormattedDate();
+  const shortSha = sha.substring(0, 7);
+  const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
+  const body = `${comment.body}\n- **Redeployed on ${date}:** [\`${shortSha}\` ${message}](${commitLink})`;
+
+  return updateComment(comment.id, body);
+};
+
+/*
+ * Entrypoint to update the existing PR comment when we close a review app.
+ * If this can't find an existing PR comment, it doesn't do anything.
+ */
+module.exports.postDeleteComment = async function () {
+  const comment = await findExistingComment();
+  if (!comment) {
+    return undefined;
   }
 
-  const dashboardUrl = `https://dashboard.heroku.com/apps/${appName}`;
-  links.push(`:mag: **Inspect the app:** ${dashboardUrl}`);
-
-  links.push(`:compass: **Take it for a spin:** ${appUrl}`);
-
-  return links;
-}
-
-module.exports.postCreateComment = async function (appName, appUrl, message) {
-  const comment = formatComment({
-    image: owlberts.create,
-    imageLink: appUrl,
-    headline: 'A review app has been launched for this PR!',
-    body: buildLinks(appName, appUrl, message).join('\n\n'),
-  });
-  return postComment(comment);
-};
-
-module.exports.postUpdateComment = async function (appName, appUrl, message) {
-  const comment = formatComment({
-    image: owlberts.update,
-    imageLink: appUrl,
-    headline: 'This PR’s review app has been redeployed!',
-    body: buildLinks(appName, appUrl, message).join('\n\n'),
-  });
-  return postComment(comment);
-};
-
-module.exports.postDeleteComment = async function () {
-  const comment = formatComment({
-    image: owlberts.delete,
-    headline: 'This PR’s review app has been shut down.',
-    body: `:sponge: Since this PR is closed, its review app has been cleaned up.`,
-  });
-  return postComment(comment);
+  const date = getFormattedDate();
+  const body = `${comment.body}\n- **Shut down on ${date}:** Since this PR is closed, its review app has been cleaned up. :sponge:`;
+  return updateComment(comment.id, body);
 };

--- a/src/comments.js
+++ b/src/comments.js
@@ -42,15 +42,18 @@ function formatComment(options) {
   return result;
 }
 
-function buildLinks(appName, appUrl, sha, message) {
+function buildLinks(appName, appUrl, message) {
   const links = [];
 
-  if (sha && message) {
-    const owner = github.context.payload.repository.owner.login;
-    const repo = github.context.payload.repository.name;
-    const prNumber = parseInt(github.context.payload.number, 10);
+  const owner = github.context.payload.repository.owner.login;
+  const repo = github.context.payload.repository.name;
+  const prNumber = parseInt(github.context.payload.number, 10);
+  const sha = github.context.sha;
+
+  if (owner && repo && prNumber && sha && message) {
     const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
-    links.push(`:rocket: **Deployed commit:** [\`${sha.substring(0, 8)}\` ${message}](${commitLink})`);
+    const commitText = `\`${sha.substring(0, 8)}\` ${message.split('\n')[0]}`;
+    links.push(`:rocket: **Deployed commit:** [${commitText}](${commitLink})`);
   }
 
   const dashboardUrl = `https://dashboard.heroku.com/apps/${appName}`;
@@ -61,22 +64,22 @@ function buildLinks(appName, appUrl, sha, message) {
   return links;
 }
 
-module.exports.postCreateComment = async function (appName, appUrl, sha, message) {
+module.exports.postCreateComment = async function (appName, appUrl, message) {
   const comment = formatComment({
     image: owlberts.create,
     imageLink: appUrl,
     headline: 'A review app has been launched for this PR!',
-    body: buildLinks(appName, appUrl, sha, message).join('\n\n'),
+    body: buildLinks(appName, appUrl, message).join('\n\n'),
   });
   return postComment(comment);
 };
 
-module.exports.postUpdateComment = async function (appName, appUrl, sha, message) {
+module.exports.postUpdateComment = async function (appName, appUrl, message) {
   const comment = formatComment({
     image: owlberts.update,
     imageLink: appUrl,
     headline: 'This PR’s review app has been redeployed!',
-    body: buildLinks(appName, appUrl, sha, message).join('\n\n'),
+    body: buildLinks(appName, appUrl, message).join('\n\n'),
   });
   return postComment(comment);
 };

--- a/src/comments.js
+++ b/src/comments.js
@@ -52,12 +52,6 @@ function getOctokit() {
  * the PR is closed and reopened, this the most recent.
  */
 async function findExistingComment() {
-  core.info('calling octokit.rest.issues.listComments with these params:');
-  core.info(`    owner: ${github.context.payload.repository.owner.login}`);
-  core.info(`    repo: ${github.context.payload.repository.name}`);
-  core.info(`    issue_number: ${parseInt(github.context.payload.number, 10)}`);
-  core.info('    per_page: 100');
-
   const octokit = getOctokit();
   const resp = await octokit.rest.issues.listComments({
     owner: github.context.payload.repository.owner.login,
@@ -65,10 +59,11 @@ async function findExistingComment() {
     issue_number: parseInt(github.context.payload.number, 10),
     per_page: 100,
   });
-  // TODO validate resp
-  core.info(`GitHub API returned status ${resp.status} and ${resp.data.length} comments`);
+  if (resp.status > 400) {
+    core.warning(`GitHub listComments API call returned HTTP status ${resp.status}`);
+    return undefined;
+  }
   const reviewAppComments = resp.data.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes(owlbert));
-  core.info(`With filter, there are ${reviewAppComments.length} matching comments`);
   if (reviewAppComments.length > 0) {
     // the last comment in the array is the most recent
     return reviewAppComments[reviewAppComments.length - 1];
@@ -80,21 +75,16 @@ async function findExistingComment() {
  * Sends a new comment to GitHub.
  */
 async function createComment(body) {
-  core.info('calling octokit.rest.issues.createComment with these params:');
-  core.info(`    owner: ${github.context.payload.repository.owner.login}`);
-  core.info(`    repo: ${github.context.payload.repository.name}`);
-  core.info(`    issue_number: ${parseInt(github.context.payload.number, 10)}`);
-  core.info(`    body: ${body.length} characters`);
-
   const octokit = getOctokit();
-  const resp = octokit.rest.issues.createComment({
+  const resp = await octokit.rest.issues.createComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     issue_number: parseInt(github.context.payload.number, 10),
     body,
   });
-  // TODO validate resp
-  core.info(`GitHub API returned status ${resp.status}`);
+  if (resp.status > 400) {
+    core.warning(`GitHub createComment API call returned HTTP status ${resp.status}`);
+  }
   return resp;
 }
 
@@ -102,21 +92,16 @@ async function createComment(body) {
  * Modifies an existing comment on GitHub.
  */
 async function updateComment(commentId, body) {
-  core.info('calling octokit.rest.issues.updateComment with these params:');
-  core.info(`    owner: ${github.context.payload.repository.owner.login}`);
-  core.info(`    repo: ${github.context.payload.repository.name}`);
-  core.info(`    comment_id: ${commentId}`);
-  core.info(`    body: ${body.length} characters`);
-
   const octokit = getOctokit();
-  const resp = octokit.rest.issues.updateComment({
+  const resp = await octokit.rest.issues.updateComment({
     owner: github.context.payload.repository.owner.login,
     repo: github.context.payload.repository.name,
     comment_id: commentId,
     body,
   });
-  // TODO validate resp
-  core.info(`GitHub API returned status ${resp.status}`);
+  if (resp.status > 400) {
+    core.warning(`GitHub updateComment API call returned HTTP status ${resp.status}`);
+  }
   return resp;
 }
 
@@ -124,32 +109,20 @@ async function updateComment(commentId, body) {
  * Entrypoint to post a new PR comment when we open a new review app.
  */
 module.exports.postCreateComment = async function (appName, appUrl) {
-  core.info('running postCreateComment with these params:');
-  core.info(`    appName: ${appName}`);
-  core.info(`    appUrl: ${appUrl}`);
-
   const dashboardUrl = `https://dashboard.heroku.com/apps/${appName}`;
   const img = `<a href="${appUrl}"><img align="right" height="100" src="${owlbert}" /></a>`;
   const links = `:mag: **Inspect the app:** ${dashboardUrl}\n\n:compass: **Take it for a spin:** ${appUrl}`;
 
   const comment = `## A review app has been launched for this PR! ${img}\n\n${links}\n`;
-  const resp = await createComment(comment);
-
-  core.info('Finished running postCreateComment\n');
-  return resp;
+  return createComment(comment);
 };
 
 /*
- * Entrypoint to update the existing PR comment when we open a new review app.
- * If this can't find an existing PR comment, it can just create a new one.
+ * Entrypoint to update the existing PR comment, appending a bullet that we've
+ * redeployed the review app. If this can't find an existing PR comment, it will
+ * create a new comment instead.
  */
 module.exports.postUpdateComment = async function (appName, appUrl, sha, message) {
-  core.info('running postUpdateComment with these params:');
-  core.info(`    appName: ${appName}`);
-  core.info(`    appUrl: ${appUrl}`);
-  core.info(`    sha: ${sha}`);
-  core.info(`    message: ${message}`);
-
   const comment = await findExistingComment();
   if (!comment) {
     return module.exports.postCreateComment(appName, appUrl);
@@ -164,18 +137,15 @@ module.exports.postUpdateComment = async function (appName, appUrl, sha, message
   const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
   const body = `${comment.body}\n- **Redeployed on ${date}:** [\`${shortSha}\` ${message}](${commitLink})`;
 
-  const resp = await updateComment(comment.id, body);
-
-  core.info('Finished running postUpdateComment\n');
-  return resp;
+  return updateComment(comment.id, body);
 };
 
 /*
- * Entrypoint to update the existing PR comment when we close a review app.
- * If this can't find an existing PR comment, it doesn't do anything.
+ * Entrypoint to update the existing PR comment, appending a bullet that we've
+ * shut down the review app. If this can't find an existing PR comment, it
+ * doesn't do anything.
  */
 module.exports.postDeleteComment = async function () {
-  core.info('running postDeleteComment with no params:');
   const comment = await findExistingComment();
   if (!comment) {
     return undefined;
@@ -183,8 +153,5 @@ module.exports.postDeleteComment = async function () {
 
   const date = getFormattedDate();
   const body = `${comment.body}\n- **Shut down on ${date}:** Since this PR is closed, its review app has been cleaned up. :sponge:`;
-  const resp = await updateComment(comment.id, body);
-
-  core.info('Finished running postDeleteComment\n');
-  return resp;
+  return updateComment(comment.id, body);
 };

--- a/src/comments.js
+++ b/src/comments.js
@@ -155,14 +155,9 @@ module.exports.postUpdateComment = async function (appName, appUrl, sha, message
     return module.exports.postCreateComment(appName, appUrl);
   }
 
-  const owner = github.context.payload.repository.owner.login;
-  const repo = github.context.payload.repository.name;
-  const prNumber = parseInt(github.context.payload.number, 10);
-
   const date = getFormattedDate();
   const shortSha = sha.substring(0, 7);
-  const commitLink = `https://github.com/${owner}/${repo}/pull/${prNumber}/commits/${sha}`;
-  const body = `${comment.body}\n- **Redeployed on ${date}:** [\`${shortSha}\` ${message}](${commitLink})`;
+  const body = `${comment.body}\n- **Redeployed on ${date}:** ${shortSha} ${message}`;
 
   const resp = await updateComment(comment.id, body);
 

--- a/src/controllers/create.js
+++ b/src/controllers/create.js
@@ -14,6 +14,8 @@ async function createController(params) {
   if (!git.refExists(refName)) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
+  const sha = git.shaForRef(refName);
+  const message = git.messageForRef(refName).split('\n')[0];
 
   const configVars = templateApp ? await heroku.getAppVars(templateApp) : await heroku.getPipelineVars(pipelineId);
 
@@ -68,7 +70,7 @@ async function createController(params) {
   }
 
   core.info(`\nSuccessfully created Heroku app "${appName}"! Your app is available at:\n    ${appUrl}\n`);
-  await comments.postCreateComment(appName, appUrl);
+  await comments.postCreateComment(appName, appUrl, sha, message);
   return true;
 }
 

--- a/src/controllers/create.js
+++ b/src/controllers/create.js
@@ -14,8 +14,7 @@ async function createController(params) {
   if (!git.refExists(refName)) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
-  const sha = git.shaForRef(refName);
-  const message = git.messageForRef(refName).split('\n')[0];
+  const message = git.messageForRef(refName);
 
   const configVars = templateApp ? await heroku.getAppVars(templateApp) : await heroku.getPipelineVars(pipelineId);
 
@@ -70,7 +69,7 @@ async function createController(params) {
   }
 
   core.info(`\nSuccessfully created Heroku app "${appName}"! Your app is available at:\n    ${appUrl}\n`);
-  await comments.postCreateComment(appName, appUrl, sha, message);
+  await comments.postCreateComment(appName, appUrl, message);
   return true;
 }
 

--- a/src/controllers/update.js
+++ b/src/controllers/update.js
@@ -1,6 +1,7 @@
 const comments = require('../comments');
 const core = require('@actions/core');
 const git = require('../git');
+const github = require('@actions/github');
 const heroku = require('../heroku');
 
 async function updateController(params) {
@@ -14,6 +15,7 @@ async function updateController(params) {
   if (!git.refExists(refName)) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
+  const sha = github.context.sha;
   const message = git.messageForRef(refName);
 
   let appUrl;
@@ -33,7 +35,7 @@ async function updateController(params) {
   }
 
   core.info(`\nSuccessfully deployed changes to Heroku app "${appName}"! Your app is available at:\n    ${appUrl}\n`);
-  await comments.postUpdateComment(appName, appUrl, message);
+  await comments.postUpdateComment(appName, appUrl, sha, message);
   return true;
 }
 

--- a/src/controllers/update.js
+++ b/src/controllers/update.js
@@ -15,7 +15,7 @@ async function updateController(params) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
   const sha = git.shaForRef(refName); // can't use github.context.sha because we want to exclude merge commits
-  const message = git.messageForRef(refName).split('\n')[0]; // only include the first line in the comment
+  const message = git.messageForRef(refName);
 
   let appUrl;
   if (pipelineName === 'readme') {

--- a/src/controllers/update.js
+++ b/src/controllers/update.js
@@ -14,6 +14,8 @@ async function updateController(params) {
   if (!git.refExists(refName)) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
+  const sha = git.shaForRef(refName);
+  const message = git.messageForRef(refName).split('\n')[0];
 
   let appUrl;
   if (pipelineName === 'readme') {
@@ -32,7 +34,7 @@ async function updateController(params) {
   }
 
   core.info(`\nSuccessfully deployed changes to Heroku app "${appName}"! Your app is available at:\n    ${appUrl}\n`);
-  await comments.postUpdateComment(appName, appUrl);
+  await comments.postUpdateComment(appName, appUrl, sha, message);
   return true;
 }
 

--- a/src/controllers/update.js
+++ b/src/controllers/update.js
@@ -15,7 +15,7 @@ async function updateController(params) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
   const sha = git.shaForRef(refName); // can't use github.context.sha because we want to exclude merge commits
-  const message = git.messageForRef(refName);
+  const message = git.messageForRef(refName).split('\n')[0]; // only include the first line in the comment
 
   let appUrl;
   if (pipelineName === 'readme') {

--- a/src/controllers/update.js
+++ b/src/controllers/update.js
@@ -14,8 +14,7 @@ async function updateController(params) {
   if (!git.refExists(refName)) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
-  const sha = git.shaForRef(refName);
-  const message = git.messageForRef(refName).split('\n')[0];
+  const message = git.messageForRef(refName);
 
   let appUrl;
   if (pipelineName === 'readme') {
@@ -34,7 +33,7 @@ async function updateController(params) {
   }
 
   core.info(`\nSuccessfully deployed changes to Heroku app "${appName}"! Your app is available at:\n    ${appUrl}\n`);
-  await comments.postUpdateComment(appName, appUrl, sha, message);
+  await comments.postUpdateComment(appName, appUrl, message);
   return true;
 }
 

--- a/src/controllers/update.js
+++ b/src/controllers/update.js
@@ -1,7 +1,6 @@
 const comments = require('../comments');
 const core = require('@actions/core');
 const git = require('../git');
-const github = require('@actions/github');
 const heroku = require('../heroku');
 
 async function updateController(params) {
@@ -15,7 +14,7 @@ async function updateController(params) {
   if (!git.refExists(refName)) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
-  const sha = github.context.sha;
+  const sha = git.shaForRef(refName); // can't use github.context.sha because we want to exclude merge commits
   const message = git.messageForRef(refName);
 
   let appUrl;

--- a/src/git.js
+++ b/src/git.js
@@ -15,6 +15,19 @@ function git(command, args, captureOutput = false) {
   return result;
 }
 
+/*
+ * Returns the short commit message the latest commit in the given ref. This is
+ * usually only the first line of the message, but can occasionally be more than
+ * one line, for example in merge commits.
+ */
+function gitLog(ref, format) {
+  const result = git('log', [`--pretty=format:${format}`, '--no-merges', '--quiet', `${ref}~1..${ref}`], true);
+  if (result.status !== 0) {
+    return undefined;
+  }
+  return result.stdout.toString().trim();
+}
+
 /* Checks whether the current directory contains a Git repo. Returns bool. */
 module.exports.repoExists = () => {
   try {
@@ -32,16 +45,19 @@ module.exports.refExists = ref => {
 };
 
 /*
- * Returns the short commit message the latest commit in the given ref. This is
- * usually only the first line of the message, but can occasionally be more than
- * one line, for example in merge commits.
+ * Returns the SHA hash of the latest commit in the given ref.
+ */
+module.exports.shaForRef = ref => {
+  return gitLog(ref, '%H');
+};
+
+/*
+ * Returns the short commit message of the latest commit in the given ref. This
+ * is usually only the first line of the message, but can occasionally be more
+ * than one line, for example in merge commits.
  */
 module.exports.messageForRef = ref => {
-  const result = git('log', ['--pretty=format:%s', '--quiet', `${ref}~1..${ref}`], true);
-  if (result.status !== 0) {
-    return undefined;
-  }
-  return result.stdout.toString().trim();
+  return gitLog(ref, '%s');
 };
 
 /*

--- a/src/git.js
+++ b/src/git.js
@@ -25,7 +25,8 @@ function gitLog(ref, format) {
   if (result.status !== 0) {
     return undefined;
   }
-  return result.stdout.toString().trim();
+  // convert the buffer to a string, then return just the first line
+  return result.stdout.toString().trim().split('\n')[0];
 }
 
 /* Checks whether the current directory contains a Git repo. Returns bool. */

--- a/src/git.js
+++ b/src/git.js
@@ -31,15 +31,6 @@ module.exports.refExists = ref => {
   return result.status === 0;
 };
 
-/* Returns the SHA-1 hash of the latest commit in the given ref. */
-module.exports.shaForRef = ref => {
-  const result = git('rev-parse', ['--verify', '--quiet', ref], true);
-  if (result.status !== 0) {
-    return undefined;
-  }
-  return result.stdout.toString().trim();
-};
-
 /*
  * Returns the short commit message the latest commit in the given ref. This is
  * usually only the first line of the message, but can occasionally be more than

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -5,6 +5,7 @@ const git = require('../src/git');
 const SAMPLE_APP_NAME = 'dr-owlbert-pr-1234';
 const SAMPLE_REF = 'refs/heads/dev';
 const SAMPLE_EMAIL = 'jest-test-user@example.com';
+const SAMPLE_SHA = '1234567890123456789012345678901234567890';
 const SAMPLE_API_KEY = '12345678-1234-1234-1234-1234567890ab';
 const SAMPLE_MESSAGE = 'chore: replace Owlbert with Dewey Duck';
 const SAMPLE_MULTILINE_MESSAGE =
@@ -49,8 +50,29 @@ describe('#src/git', () => {
     });
   });
 
+  describe('shaForRef()', () => {
+    const EXPECTED_ARGS = ['log', '--pretty=format:%H', '--no-merges', '--quiet', `${SAMPLE_REF}~1..${SAMPLE_REF}`];
+
+    it('should return the commit hash if the "git log" command succeeds', () => {
+      const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({
+        status: 0,
+        stdout: Buffer.from(`${SAMPLE_SHA}\n`),
+      });
+      expect(git.shaForRef(SAMPLE_REF)).toBe(SAMPLE_SHA);
+      expect(spy.mock.lastCall[0]).toBe('git');
+      expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
+    });
+
+    it('should return undefined if the "git log" command fails', () => {
+      const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({ status: 1 });
+      expect(git.shaForRef(SAMPLE_REF)).toBeUndefined();
+      expect(spy.mock.lastCall[0]).toBe('git');
+      expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
+    });
+  });
+
   describe('messageForRef()', () => {
-    const EXPECTED_ARGS = ['log', '--pretty=format:%s', '--quiet', `${SAMPLE_REF}~1..${SAMPLE_REF}`];
+    const EXPECTED_ARGS = ['log', '--pretty=format:%s', '--no-merges', '--quiet', `${SAMPLE_REF}~1..${SAMPLE_REF}`];
 
     it('should return the commit message if the "git log" command succeeds', () => {
       const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -4,7 +4,6 @@ const git = require('../src/git');
 
 const SAMPLE_APP_NAME = 'dr-owlbert-pr-1234';
 const SAMPLE_REF = 'refs/heads/dev';
-const SAMPLE_SHA = '0123456789abcdef0123456789abcdef01234567';
 const SAMPLE_EMAIL = 'jest-test-user@example.com';
 const SAMPLE_API_KEY = '12345678-1234-1234-1234-1234567890ab';
 const SAMPLE_MESSAGE = 'chore: replace Owlbert with Dewey Duck';
@@ -45,27 +44,6 @@ describe('#src/git', () => {
     it('should return false if the "git show-ref" command fails', () => {
       const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({ status: 1 });
       expect(git.refExists(SAMPLE_REF)).toBe(false);
-      expect(spy.mock.lastCall[0]).toBe('git');
-      expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
-    });
-  });
-
-  describe('shaForRef()', () => {
-    const EXPECTED_ARGS = ['rev-parse', '--verify', '--quiet', SAMPLE_REF];
-
-    it('should return true if the "git rev-parse" command succeeds', () => {
-      const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({
-        status: 0,
-        stdout: Buffer.from(`${SAMPLE_SHA}\n`),
-      });
-      expect(git.shaForRef(SAMPLE_REF)).toBe(SAMPLE_SHA);
-      expect(spy.mock.lastCall[0]).toBe('git');
-      expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
-    });
-
-    it('should return undefined if the "git rev-parse" command fails', () => {
-      const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({ status: 1 });
-      expect(git.shaForRef(SAMPLE_REF)).toBeUndefined();
       expect(spy.mock.lastCall[0]).toBe('git');
       expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
     });

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -7,9 +7,9 @@ const SAMPLE_REF = 'refs/heads/dev';
 const SAMPLE_EMAIL = 'jest-test-user@example.com';
 const SAMPLE_SHA = '1234567890123456789012345678901234567890';
 const SAMPLE_API_KEY = '12345678-1234-1234-1234-1234567890ab';
-const SAMPLE_MESSAGE = 'chore: replace Owlbert with Dewey Duck';
+const SAMPLE_SINGLE_LINE_MESSAGE = 'chore: replace Dewey Duck with Owlbert';
 const SAMPLE_MULTILINE_MESSAGE =
-  'Merge pull request #50 from readmeio/dr-owlbert\nchore: replace Owlbert with Louie Duck';
+  "chore: replace Dewey Duck with Owlbert\nHuey, Dewey, or Louie? Let's go with an owl instead.";
 
 describe('#src/git', () => {
   afterEach(() => {
@@ -63,6 +63,16 @@ describe('#src/git', () => {
       expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
     });
 
+    it('should return only the first line if the "git log" response contains multiple lines', () => {
+      const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({
+        status: 0,
+        stdout: Buffer.from(`${SAMPLE_SHA}\n${SAMPLE_SHA}\n${SAMPLE_SHA}\n`),
+      });
+      expect(git.shaForRef(SAMPLE_REF)).toBe(SAMPLE_SHA);
+      expect(spy.mock.lastCall[0]).toBe('git');
+      expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
+    });
+
     it('should return undefined if the "git log" command fails', () => {
       const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({ status: 1 });
       expect(git.shaForRef(SAMPLE_REF)).toBeUndefined();
@@ -77,19 +87,19 @@ describe('#src/git', () => {
     it('should return the commit message if the "git log" command succeeds', () => {
       const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({
         status: 0,
-        stdout: Buffer.from(`${SAMPLE_MESSAGE}\n`),
+        stdout: Buffer.from(`${SAMPLE_SINGLE_LINE_MESSAGE}\n`),
       });
-      expect(git.messageForRef(SAMPLE_REF)).toBe(SAMPLE_MESSAGE);
+      expect(git.messageForRef(SAMPLE_REF)).toBe(SAMPLE_SINGLE_LINE_MESSAGE);
       expect(spy.mock.lastCall[0]).toBe('git');
       expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
     });
 
-    it('should return multiple lines if the "git log" response contains multiple lines', () => {
+    it('should return only the first line if the "git log" response contains multiple lines', () => {
       const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({
         status: 0,
         stdout: Buffer.from(`${SAMPLE_MULTILINE_MESSAGE}\n`),
       });
-      expect(git.messageForRef(SAMPLE_REF)).toBe(SAMPLE_MULTILINE_MESSAGE);
+      expect(git.messageForRef(SAMPLE_REF)).toBe(SAMPLE_SINGLE_LINE_MESSAGE);
       expect(spy.mock.lastCall[0]).toBe('git');
       expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
     });

--- a/test/git.test.js
+++ b/test/git.test.js
@@ -4,8 +4,12 @@ const git = require('../src/git');
 
 const SAMPLE_APP_NAME = 'dr-owlbert-pr-1234';
 const SAMPLE_REF = 'refs/heads/dev';
+const SAMPLE_SHA = '0123456789abcdef0123456789abcdef01234567';
 const SAMPLE_EMAIL = 'jest-test-user@example.com';
 const SAMPLE_API_KEY = '12345678-1234-1234-1234-1234567890ab';
+const SAMPLE_MESSAGE = 'chore: replace Owlbert with Dewey Duck';
+const SAMPLE_MULTILINE_MESSAGE =
+  'Merge pull request #50 from readmeio/dr-owlbert\nchore: replace Owlbert with Louie Duck';
 
 describe('#src/git', () => {
   afterEach(() => {
@@ -41,6 +45,58 @@ describe('#src/git', () => {
     it('should return false if the "git show-ref" command fails', () => {
       const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({ status: 1 });
       expect(git.refExists(SAMPLE_REF)).toBe(false);
+      expect(spy.mock.lastCall[0]).toBe('git');
+      expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
+    });
+  });
+
+  describe('shaForRef()', () => {
+    const EXPECTED_ARGS = ['rev-parse', '--verify', '--quiet', SAMPLE_REF];
+
+    it('should return true if the "git rev-parse" command succeeds', () => {
+      const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({
+        status: 0,
+        stdout: Buffer.from(`${SAMPLE_SHA}\n`),
+      });
+      expect(git.shaForRef(SAMPLE_REF)).toBe(SAMPLE_SHA);
+      expect(spy.mock.lastCall[0]).toBe('git');
+      expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
+    });
+
+    it('should return undefined if the "git rev-parse" command fails', () => {
+      const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({ status: 1 });
+      expect(git.shaForRef(SAMPLE_REF)).toBeUndefined();
+      expect(spy.mock.lastCall[0]).toBe('git');
+      expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
+    });
+  });
+
+  describe('messageForRef()', () => {
+    const EXPECTED_ARGS = ['log', '--pretty=format:%s', '--quiet', `${SAMPLE_REF}~1..${SAMPLE_REF}`];
+
+    it('should return the commit message if the "git log" command succeeds', () => {
+      const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({
+        status: 0,
+        stdout: Buffer.from(`${SAMPLE_MESSAGE}\n`),
+      });
+      expect(git.messageForRef(SAMPLE_REF)).toBe(SAMPLE_MESSAGE);
+      expect(spy.mock.lastCall[0]).toBe('git');
+      expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
+    });
+
+    it('should return multiple lines if the "git log" response contains multiple lines', () => {
+      const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({
+        status: 0,
+        stdout: Buffer.from(`${SAMPLE_MULTILINE_MESSAGE}\n`),
+      });
+      expect(git.messageForRef(SAMPLE_REF)).toBe(SAMPLE_MULTILINE_MESSAGE);
+      expect(spy.mock.lastCall[0]).toBe('git');
+      expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
+    });
+
+    it('should return undefined if the "git log" command fails', () => {
+      const spy = jest.spyOn(childProcess, 'spawnSync').mockReturnValue({ status: 1 });
+      expect(git.messageForRef(SAMPLE_REF)).toBeUndefined();
       expect(spy.mock.lastCall[0]).toBe('git');
       expect(spy.mock.lastCall[1]).toStrictEqual(EXPECTED_ARGS);
     });


### PR DESCRIPTION
Based on a suggestion from Kanad, I've updated PR messages to add the commit that was deployed. If you do multiple `git push`es in succession, and it takes a while for the app to redeploy, it's sometimes hard to tell exactly which commit is currently on Heroku.

Example of the new message:

<img width="925" alt="Screen Shot 2022-05-17 at 2 18 15 PM" src="https://user-images.githubusercontent.com/313895/168911935-b89d2679-f226-46a1-9270-5d351fe30a98.png">