### PR TITLE
feat: configure an optional log drain on new review apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ jobs:
 
 Once that file has been committed to your main branch, this should automatically open and close review apps as needed.
 
+## GitHub Action parameters
+
+* `heroku_api_key`: Personal API key for a Heroku user. Required.
+* `heroku_email`: Email address of that Heroku user. Required.
+* `pipeline_name`: Name of the Heroku pipeline which contains review apps for this repo. Must already exist in Heroku. Required.
+* `log_drain_url`: If specified, this log drain will be added to review apps when they are created. If you want to include the PR number in the URL, you can use `${{github.event.number}}`. Optional.
 
 ## Caveats
 

--- a/src/controllers/create.js
+++ b/src/controllers/create.js
@@ -4,7 +4,7 @@ const git = require('../git');
 const heroku = require('../heroku');
 
 async function createController(params) {
-  const { pipelineName, pipelineId, appName, refName } = params;
+  const { pipelineName, pipelineId, logDrainUrl, appName, refName } = params;
 
   // Additional validation specific to the "create" action
   const exists = await heroku.appExists(appName);
@@ -20,6 +20,9 @@ async function createController(params) {
 
   let stepCount = 4;
   if (Object.keys(configVars).length > 0) {
+    stepCount += 1;
+  }
+  if (logDrainUrl) {
     stepCount += 1;
   }
   if (pipelineName === 'readme') {
@@ -45,6 +48,12 @@ async function createController(params) {
     currentStep += 1;
     core.info(`[Step ${currentStep}/${stepCount}] Setting default config vars...`);
     await heroku.setAppVars(app.id, configVars);
+  }
+
+  if (logDrainUrl) {
+    currentStep += 1;
+    core.info(`[Step ${currentStep}/${stepCount}] Configuring app to send logs to Logstash...`);
+    await heroku.addDrain(app.id, logDrainUrl);
   }
 
   currentStep += 1;

--- a/src/heroku.js
+++ b/src/heroku.js
@@ -186,6 +186,18 @@ module.exports.setAppVars = async function (appId, vars) {
   return resp.json();
 };
 
+/*
+ * Adds a log drain to the given app
+ */
+module.exports.addDrain = async function (appId, url) {
+  const resp = await herokuFetch(`https://api.heroku.com/apps/${appId}/log-drains`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ url }),
+  });
+  return resp.json();
+};
+
 /* Creates a new one-off dyno to run the given command in the background. */
 module.exports.runAppCommand = async function (appId, command) {
   const resp = await herokuFetch(`https://api.heroku.com/apps/${appId}/dynos`, {

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,8 @@ async function getParams() {
     throw new Error(`The pipeline "${pipelineName}" does not exist on Heroku`);
   }
 
+  const logDrainUrl = core.getInput('log_drain_url', { required: false });
+
   let baseName;
   const reviewAppConfig = await heroku.getReviewAppConfig(pipelineId);
   if (reviewAppConfig) {
@@ -40,7 +42,7 @@ async function getParams() {
 
   const refName = `refs/remotes/pull/${prNumber}/merge`;
 
-  return { pipelineName, pipelineId, baseName, appName, refName };
+  return { pipelineName, pipelineId, logDrainUrl, baseName, appName, refName };
 }
 
 /*
@@ -51,13 +53,14 @@ async function main() {
     heroku.initializeCredentials();
 
     const params = await getParams();
-    const { pipelineName, pipelineId, baseName, appName, refName } = params;
+    const { pipelineName, pipelineId, logDrainUrl, baseName, appName, refName } = params;
 
     core.info('Heroku Review App Action invoked with these parameters:');
     core.info(`  - Action: ${github.context.payload.action}`);
     core.info(`  - Git ref: ${refName}`);
     core.info(`  - Heroku pipeline name: ${pipelineName}`);
     core.info(`  - Heroku pipeline ID: ${pipelineId}`);
+    core.info(`  - Log drain URL: ${logDrainUrl || 'none'}`);
     core.info(`  - Review app base name: ${baseName}`);
     core.info(`  - Heroku app name: ${appName}`);
 

--- a/test/heroku.test.js
+++ b/test/heroku.test.js
@@ -5,6 +5,7 @@ const SAMPLE_APP_ID = '33333333-4444-5555-6666-777777777777';
 const SAMPLE_APP_NAME = 'dr-owlbert-pr-1234';
 const SAMPLE_COMMAND = 'npm run lint';
 const SAMPLE_CONFIG_VARS = { MAILCHIMP_API_KEY: '123', NODE_ENV: 'pr' };
+const SAMPLE_DRAIN_URL = 'https://logs.example.com/my-log-drain';
 const SAMPLE_PIPELINE_ID = '12121212-3434-5656-7878-909090909090';
 const SAMPLE_PIPELINE_NAME = 'aqueduct';
 const SAMPLE_RESPONSE = { response_field: 'response_value' };
@@ -129,6 +130,15 @@ describe('#src/heroku', () => {
           .patch(`/apps/${SAMPLE_APP_ID}/config-vars`, SAMPLE_CONFIG_VARS)
           .reply(200, SAMPLE_RESPONSE);
         await expect(heroku.setAppVars(SAMPLE_APP_ID, SAMPLE_CONFIG_VARS)).resolves.toStrictEqual(SAMPLE_RESPONSE);
+      });
+    });
+
+    describe('addDrain()', () => {
+      it('should POST to the correct endpoint to set up a log drain', async () => {
+        nock('https://api.heroku.com')
+          .post(`/apps/${SAMPLE_APP_ID}/log-drains`, { url: SAMPLE_DRAIN_URL })
+          .reply(200, SAMPLE_RESPONSE);
+        await expect(heroku.addDrain(SAMPLE_APP_ID, SAMPLE_DRAIN_URL)).resolves.toStrictEqual(SAMPLE_RESPONSE);
       });
     });
 


### PR DESCRIPTION
(low urgency)

Optionally lets us configure a Heroku [log drain](https://devcenter.heroku.com/articles/log-drains) so that we can send PR app logs to Logstash.

I had this sitting around in my local Git repo for a few weeks, just noticed it.