### PR TITLE
feat: use CI to check if dist/index.js needs to be rebuilt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,16 @@ jobs:
 
       - run:
           name: Building with ncc
-          command: npm run build
+          command: |
+            mv dist/index.js dist/index.js.orig
+            npm run build
+            ORIGINAL_BUILD_CHECKSUM="$(cat dist/index.js.orig | md5sum)"
+            NEW_BUILD_CHECKSUM="$(cat dist/index.js | md5sum)"
+            if [ "${ORIGINAL_BUILD_CHECKSUM}" != "${NEW_BUILD_CHECKSUM}" ]; then
+              echo "Warning: ncc build doesn't match what's checked into dist/index.js."
+              echo "Did you forget to 'npm run build' on this branch?"
+              exit 1
+            fi
 
       - run:
           name: Running unit tests


### PR DESCRIPTION
## 🧰 Changes

We use [ncc](https://github.com/vercel/ncc) to compile a build of the GitHub Action that can run without needing an `npm install` on every run. This simplifies the GitHub workflow files that we put in every repo, but it means that we have to check in a compiled artifact every time we make changes. I keep forgetting to do that. 😭 (I already have a husky post-commit action but that doesn't seem to run consistently…)

There are probably better ways to do this automatically but for a quick fix, this seems better than doing nothing. 

## 🧬 QA & Testing

When I "forgot" to run `npm run build`, the commit [failed CI](https://app.circleci.com/pipelines/github/readmeio/heroku-review-app-action/115/workflows/ee072cc2-4c5a-4d0d-9b18-c54796fab4dd/jobs/115).

When I ran `npm run build` and committed `dist/index.js`, the next commit [passed CI](https://app.circleci.com/pipelines/github/readmeio/heroku-review-app-action/116/workflows/d69c7fae-17b5-4f6d-8ffa-15c15a5eb0ea/jobs/116).
