### PR TITLE
feat: post error message to PR thread

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8938,7 +8938,7 @@ module.exports.postErrorComment = async function (params) {
   const img = `<a href="${actionUrl}"><img align="right" height="100" src="${sadOwlbert}" /></a>`;
   const links = `:page_facing_up: **Review the GitHub Action logs:** ${actionUrl}\n\n:mag: **Inspect the app in Heroku:** ${dashboardUrl}`;
 
-  const comment = `## Something went wrong: this review app couldn‘t be deployed to Heroku. ${img}\n\n${runDescription} failed.\n\n${links}\n`;
+  const comment = `## :warning: There was a problem deploying this review app to Heroku. ${img}\n\n${runDescription} failed.\n\n${links}\n`;
   return createComment(comment);
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -9492,7 +9492,7 @@ async function main() {
           break;
       }
     } catch (err) {
-      comments.postErrorComment(params);
+      await comments.postErrorComment(params);
       throw err;
     }
   } catch (err) {

--- a/src/comments.js
+++ b/src/comments.js
@@ -170,6 +170,6 @@ module.exports.postErrorComment = async function (params) {
   const img = `<a href="${actionUrl}"><img align="right" height="100" src="${sadOwlbert}" /></a>`;
   const links = `:page_facing_up: **Review the GitHub Action logs:** ${actionUrl}\n\n:mag: **Inspect the app in Heroku:** ${dashboardUrl}`;
 
-  const comment = `## Something went wrong: this review app couldn‘t be deployed to Heroku. ${img}\n\n${runDescription} failed.\n\n${links}\n`;
+  const comment = `## :warning: There was a problem deploying this review app to Heroku. ${img}\n\n${runDescription} failed.\n\n${links}\n`;
   return createComment(comment);
 };

--- a/src/controllers/upsert.js
+++ b/src/controllers/upsert.js
@@ -9,6 +9,7 @@ async function upsertController(params) {
   if (!git.refExists(refName)) {
     throw new Error(`Ref "${refName}" does not exist.`);
   }
+  const sha = git.shaForRef(refName); // can't use github.context.sha because we want to exclude merge commits
   const message = git.messageForRef(refName);
   const configVars = await heroku.getPipelineVars(pipelineId);
 
@@ -86,12 +87,7 @@ async function upsertController(params) {
   }
 
   core.info(`\nSuccessfully created Heroku app "${appName}"! Your app is available at:\n    ${appUrl}\n`);
-  if (appAlreadyExists) {
-    const sha = git.shaForRef(refName); // can't use github.context.sha because we want to exclude merge commits
-    await comments.postUpdateComment(appName, appUrl, sha, message);
-  } else {
-    await comments.postCreateComment(appName, appUrl, message);
-  }
+  await comments.postUpsertComment(appName, appUrl, sha, message);
   return true;
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -87,7 +87,7 @@ async function main() {
           break;
       }
     } catch (err) {
-      comments.postErrorComment(params);
+      await comments.postErrorComment(params);
       throw err;
     }
   } catch (err) {


### PR DESCRIPTION
| 🚥 Fix RM-4856 |
| :-- |

## 🧰 Changes

Posts a pull request comment if the Heroku build/deploy fails. Here's an example:

<img width="919" alt="Screen Shot 2022-08-04 at 2 07 47 PM" src="https://user-images.githubusercontent.com/313895/182953052-6baf242e-4bca-40f8-ad8a-ab32f2f71ea7.png">

(BTW: I'm going to be switching this repo to Docker builds soon; I'm working on tickets to clean up some outstanding issues before making a bunch of changes here.)

## 🧬 QA & Testing

Tested the branch against a fake PR.
