### PR TITLE
fix: don't post deploy errors to PRs after they're already closed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['@readme/eslint-config'],
-  plugins: ['node', 'import', 'jest'],
+  plugins: ['node', 'import'],
   root: true,
   ignorePatterns: ['node_modules', 'dist'],
   rules: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: ['@readme/eslint-config'],
-  plugins: ['node', 'import'],
+  plugins: ['node', 'import', 'jest'],
   root: true,
   ignorePatterns: ['node_modules', 'dist'],
   rules: {

--- a/src/comments.js
+++ b/src/comments.js
@@ -161,8 +161,23 @@ module.exports.postDeleteComment = async function () {
 module.exports.postErrorComment = async function (params) {
   const owner = github.context.payload.repository.owner.login;
   const repo = github.context.payload.repository.name;
-  const runId = github.context.runId;
 
+  if (github.context.payload.action !== 'closed') {
+    // Deploys of large codebases will hit a race condition when a pull request
+    // is closed while a deploy is actively running. The underlying Heroku app
+    // will be closed before the deploy finishes, which causes an error on the
+    // deploy process. To resolve this, we reload the current state of the pull
+    // request and check whether the PR has been closed.
+    const octokit = getOctokit();
+    const prNumber = parseInt(github.context.payload.number, 10);
+    const resp = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
+    if (resp.data && resp.data.state === 'closed') {
+      core.warning('Not commenting on this pull request because the pull request is already closed');
+      return undefined;
+    }
+  }
+
+  const runId = github.context.runId;
   const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
   const dashboardUrl = `https://dashboard.heroku.com/apps/${params.appName}`;
   const runDescription = `${github.context.workflow} #${github.context.runNumber}`;


### PR DESCRIPTION
## 🧰 Changes

Deploys of large codebases will hit a race condition when a pull request is closed while a deploy is actively running. The underlying Heroku app will be closed before the deploy finishes, which causes an error on the running deploy process. To resolve this, we reload the current state of the pull request and check whether the PR has been closed.

## 🧬 QA & Testing

Tested on metrics-test-server by opening a pull request, which triggered GitHub Action [run #279](https://github.com/readmeio/metrics-test-server/actions/runs/3751921828/jobs/6373487165)). Then I closed it while the build was running on CircleCI, which triggered [run #280](https://github.com/readmeio/metrics-test-server/actions/runs/3751924012/jobs/6373491607) and deleted the review app.

Run #279 failed, as expected, but it didn't comment on the pull request. The output looked like this:

```
[Step 1/5] Creating Heroku app "metrics-test-server-pr-89"...
[Step 2/5] Associating app with Heroku pipeline "metrics-test-server"...
[Step 3/5] Enabling Heroku Labs features...
[Step 4/5] Setting default config vars...
[Step 5/5] Building Docker image and deploying the image to Heroku...
  - Kicked off CircleCI pipeline #752. Waiting for pipeline to finish;
    this may take some time. Watch the build progress here:
    https://app.circleci.com/pipelines/github/readmeio/metrics-test-server/752
Warning: Not commenting on this pull request because the pull request is already closed
Error: CircleCI pipeline #752 finished with status "failed".
/home/runner/work/_actions/readmeio/heroku-review-app-action/ryanp/fix-comment-after-close/dist/index.js:10004
      throw new Error(`CircleCI pipeline #${pipeline.number} finished with status "${result.status}".`);
[...]
```

(That build also included some debug output which I've removed from the snippet here. Also that PR history includes a fail message because of a bug in an earlier build of this change.)