### PR TITLE
feat: add option to change the dyno size

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Once that file has been committed to your main branch, this should automatically
 * `docker`: `true` to build a Docker image on CircleCI and ship it to Heroku, `false` to build directly on Heroku.
 * `pipeline_name`: Name of the Heroku pipeline which contains review apps for this repo. Must already exist in Heroku. Required.
 * `log_drain_url`: If specified, this log drain will be added to review apps when they are created. If you want to include the PR number in the URL, you can use `${{github.event.number}}`. Optional.
+* `heroku_size`: If specified, allows you to customize the size of the dyno used for the web server. Optional; defaults to Heroku's default size, `standard-1x`.
 
 ## Caveats
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
   heroku_region:
     description: 'Region to deploy newly-created apps'
     default: us
+  heroku_size:
+    description: 'Size of review app instances to launch on Heroku'
+    default: 'standard-1x'
   heroku_team:
     description: 'Name of the team that will own the new Heroku app.'
     default: readme

--- a/src/controllers/upsert/heroku-size.js
+++ b/src/controllers/upsert/heroku-size.js
@@ -1,0 +1,35 @@
+const core = require('@actions/core');
+
+const heroku = require('../../heroku');
+const Step = require('../step');
+
+const DEFAULT_DYNO_SIZE = 'standard-1x';
+
+class HerokuSizeStep extends Step {
+  constructor(params) {
+    super('Setting Heroku dyno size', params);
+  }
+
+  async checkPrereqs() {
+    this.currentSize = 'unknown';
+    if (await heroku.appExists(this.params.appName)) {
+      try {
+        this.currentSize = await heroku.getAppSize(this.params.appName);
+      } catch (err) {
+        // This will encounter an error if the app exists but has never been
+        // deployed. This isn't a problem -- in that case this.currentSize will
+        // be set to 'unknown' which is safe, it will force the step to run.
+      }
+    } else {
+      this.currentSize = DEFAULT_DYNO_SIZE;
+    }
+    this.shouldRun = this.params.herokuSize.toLowerCase() !== this.currentSize.toLowerCase();
+  }
+
+  async run() {
+    core.info(`  - Changing dyno size from ${this.currentSize} to ${this.params.herokuSize}`);
+    return heroku.setAppSize(this.params);
+  }
+}
+
+module.exports = HerokuSizeStep;

--- a/src/controllers/upsert/index.js
+++ b/src/controllers/upsert/index.js
@@ -8,6 +8,7 @@ const ConfigVarsStep = require('./config-vars');
 const CreateAppStep = require('./create-app');
 const DockerDeployStep = require('./docker-deploy');
 const HerokuLabsStep = require('./heroku-labs');
+const HerokuSizeStep = require('./heroku-size');
 const LogDrainStep = require('./log-drain');
 const PipelineCouplingStep = require('./pipeline-coupling');
 const SetDomainStep = require('./set-domain');
@@ -36,6 +37,7 @@ async function upsertController(params) {
     new ConfigVarsStep(params),
     new LogDrainStep(params),
     new DockerDeployStep(params),
+    new HerokuSizeStep(params),
     new SetDomainStep(params),
   ];
 

--- a/src/heroku.js
+++ b/src/heroku.js
@@ -92,6 +92,12 @@ module.exports.getAppFeature = async function (appId, featureName) {
   return herokuGet(`https://api.heroku.com/apps/${appId}/features/${featureName}`);
 };
 
+/* Loads the dyno size used for the given app */
+module.exports.getAppSize = async function (appName) {
+  const resp = await herokuGet(`https://api.heroku.com/apps/${appName}/formation/web`);
+  return resp.size;
+};
+
 /* Loads the UUID of the named pipeline from Heroku. */
 module.exports.getPipelineId = async function (pipelineName) {
   try {
@@ -171,6 +177,19 @@ module.exports.createApp = async function (params) {
   delete appCache[params.appName];
   delete appExistsCache[params.appName];
   return result;
+};
+
+/* Updates the app's "web" formation to set a specific instance size. */
+module.exports.setAppSize = async function (params) {
+  const resp = await herokuFetch(`https://api.heroku.com/apps/${params.appName}/formation/web`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      quantity: 1,
+      size: params.herokuSize,
+    }),
+  });
+  return resp.json();
 };
 
 /* Deletes a Heroku app with the given name. */

--- a/src/main.js
+++ b/src/main.js
@@ -42,6 +42,7 @@ async function getParams() {
   params.refName = `refs/remotes/pull/${prNumber}/merge`;
 
   params.herokuRegion = core.getInput('heroku_region', { required: true });
+  params.herokuSize = core.getInput('heroku_size', { required: true });
   params.herokuTeam = core.getInput('heroku_team', { required: true });
   params.nodeEnv = core.getInput('node_env', { required: false });
 
@@ -64,8 +65,13 @@ async function main() {
 
     core.info('Heroku Review App Action invoked with these parameters:');
     core.info(`  - Action: ${github.context.payload.action}`);
-    core.info(`  - Heroku pipeline: ${params.pipelineName}`);
-    core.info(`  - Heroku app name: ${params.appName}`);
+    core.info(`  - Heroku team name: ${params.herokuTeam}`);
+    core.info(`  - App name: ${params.appName}`);
+    core.info(`  - Pipeline: ${params.pipelineName}`);
+    core.info(`  - Region: ${params.herokuRegion}`);
+    core.info(`  - Dyno size: ${params.herokuSize}`);
+    core.info(`  - Log drain URL: ${params.logDrainUrl || 'none'}`);
+    core.info(`  - NODE_ENV: ${params.nodeEnv}`);
     core.info('');
 
     try {

--- a/test/controllers/upsert/heroku-size.test.js
+++ b/test/controllers/upsert/heroku-size.test.js
@@ -1,0 +1,61 @@
+const HerokuSizeStep = require('../../../src/controllers/upsert/heroku-size');
+const heroku = require('../../../src/heroku');
+
+const setupBeforeAndAfter = require('./setup');
+
+const SAMPLE_APP_NAME = 'owlzilla';
+
+describe('#src/controllers/upsert/heroku-size', () => {
+  setupBeforeAndAfter();
+
+  describe('checkPrereqs()', () => {
+    it('should not run when creating a new app if size matches the default', async () => {
+      jest.spyOn(heroku, 'appExists').mockResolvedValue(false);
+      const step = new HerokuSizeStep({ appName: SAMPLE_APP_NAME, herokuSize: 'standard-1x' });
+      await step.checkPrereqs();
+      expect(step.shouldRun).toBe(false);
+    });
+
+    it('should run when creating a new app if size differs from the default', async () => {
+      jest.spyOn(heroku, 'appExists').mockResolvedValue(false);
+      const step = new HerokuSizeStep({ appName: SAMPLE_APP_NAME, herokuSize: 'different-size' });
+      await step.checkPrereqs();
+      expect(step.shouldRun).toBe(true);
+    });
+
+    it('should not run on an existing app if the current size matches the desired size', async () => {
+      jest.spyOn(heroku, 'appExists').mockResolvedValue(true);
+      jest.spyOn(heroku, 'getAppSize').mockResolvedValue('current-size');
+      const step = new HerokuSizeStep({ appName: SAMPLE_APP_NAME, herokuSize: 'current-size' });
+      await step.checkPrereqs();
+      expect(step.shouldRun).toBe(false);
+    });
+
+    it('should run on an existing app if the current size differs from the desired size', async () => {
+      jest.spyOn(heroku, 'appExists').mockResolvedValue(true);
+      jest.spyOn(heroku, 'getAppSize').mockResolvedValue('current-size');
+      const step = new HerokuSizeStep({ appName: SAMPLE_APP_NAME, herokuSize: 'different-size' });
+      await step.checkPrereqs();
+      expect(step.shouldRun).toBe(true);
+    });
+
+    it('should run on an existing app if the formation does not exist', async () => {
+      jest.spyOn(heroku, 'appExists').mockResolvedValue(true);
+      jest.spyOn(heroku, 'getAppSize').mockRejectedValue(new Error('404 Not Found'));
+      const step = new HerokuSizeStep({ appName: SAMPLE_APP_NAME, herokuSize: 'current-size' });
+      await step.checkPrereqs();
+      expect(step.shouldRun).toBe(true);
+    });
+  });
+
+  describe('run()', () => {
+    it('should call setAppSize with correct params', async () => {
+      const SAMPLE_PARAMS = { appName: SAMPLE_APP_NAME, herokuSize: 'new-size' };
+      jest.spyOn(heroku, 'setAppSize').mockResolvedValue({ size: 'new-size' });
+      const step = new HerokuSizeStep(SAMPLE_PARAMS);
+      await step.run();
+      expect(heroku.setAppSize).toHaveBeenCalledTimes(1);
+      expect(heroku.setAppSize).toHaveBeenCalledWith(SAMPLE_PARAMS);
+    });
+  });
+});

--- a/test/heroku.test.js
+++ b/test/heroku.test.js
@@ -50,6 +50,20 @@ describe('#src/heroku', () => {
       });
     });
 
+    describe('getAppSize()', () => {
+      it('should return the size of the given app', async () => {
+        nock('https://api.heroku.com')
+          .get(`/apps/${SAMPLE_APP_NAME}/formation/web`)
+          .reply(200, { size: 'performance-l' });
+        await expect(heroku.getAppSize(SAMPLE_APP_NAME)).resolves.toStrictEqual('performance-l');
+      });
+
+      it('should throw an error if the given app or formation does not exist', async () => {
+        nock('https://api.heroku.com').get(`/apps/${SAMPLE_APP_NAME}/formation/web`).reply(404);
+        await expect(heroku.getAppSize(SAMPLE_APP_NAME)).rejects.toThrow(/404/);
+      });
+    });
+
     describe('getAppFeature()', () => {
       it('should return the configuration of the given app', async () => {
         nock('https://api.heroku.com')
@@ -173,6 +187,22 @@ describe('#src/heroku', () => {
       it('should POST to the correct endpoint to create an app', async () => {
         nock('https://api.heroku.com').post('/teams/apps', SAMPLE_POST_FIELDS).reply(200, SAMPLE_RESPONSE);
         await expect(heroku.createApp(SAMPLE_CREATE_PARAMS)).resolves.toStrictEqual(SAMPLE_RESPONSE);
+      });
+    });
+
+    describe('setAppSize()', () => {
+      it('should change the size of the given app', async () => {
+        nock('https://api.heroku.com')
+          .patch(`/apps/${SAMPLE_APP_NAME}/formation/web`, { quantity: 1, size: 'standard-2x' })
+          .reply(200, SAMPLE_RESPONSE);
+        await expect(heroku.setAppSize({ appName: SAMPLE_APP_NAME, herokuSize: 'standard-2x' })).resolves.toStrictEqual(
+          SAMPLE_RESPONSE
+        );
+      });
+
+      it('should throw an error if the given app or formation does not exist', async () => {
+        nock('https://api.heroku.com').patch(`/apps/${SAMPLE_APP_NAME}/formation/web`).reply(404);
+        await expect(heroku.setAppSize({ appName: SAMPLE_APP_NAME, size: 'standard-2x' })).rejects.toThrow(/404/);
       });
     });
 


### PR DESCRIPTION
| 🚥 Resolves ISSUE_ID |
| :------------------- |

## 🧰 Changes

Adds an option to change the dyno size when launching or redeploying review apps on Heroku. The dyno size will be checked and updated on each re-deploy.

This doesn't change the size directly; we must also deploy https://github.com/readmeio/readme/pull/9931 to bump up the size for `readme` review apps.

## 🧬 QA & Testing

Added unit tests. Tested on GitHub Actions for a new app and an existing app.